### PR TITLE
allocate merkleizers inside functions

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -473,8 +473,7 @@ func chunkedHashTreeRoot[T](
 
     when sizeof(T) == 1 or cpuEndian == littleEndian:
       var
-        remainingBytes = when sizeof(T) == 1: arr.len
-                                        else: arr.len * sizeof(T)
+        remainingBytes = arr.len * sizeof(T)
         pos = cast[ptr byte](unsafeAddr arr[0])
 
       while remainingBytes >= bytesPerChunk:

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -622,7 +622,7 @@ func mergedDataHash(x: HashArray|HashList, chunkIdx: int64): Digest =
 
   when x.T is BasicType:
     when cpuEndian == bigEndian:
-      unsupported type x # No bigendian support here!
+      unsupported typeof(x) # No bigendian support here!
 
     let
       bytes = cast[ptr UncheckedArray[byte]](unsafeAddr x.data[0])
@@ -717,7 +717,7 @@ func hashTreeRootCached*(x: HashList): Digest =
     x.hashes[0]
 
 func hash_tree_root*(x: auto): Digest =
-  trs "STARTING HASH TREE ROOT FOR TYPE ", name(type(x))
+  trs "STARTING HASH TREE ROOT FOR TYPE ", name(typeof(x))
   mixin toSszType
 
   result =
@@ -728,4 +728,4 @@ func hash_tree_root*(x: auto): Digest =
     else:
       hashTreeRootAux toSszType(x)
 
-  trs "HASH TREE ROOT FOR ", name(type x), " = ", "0x", $result
+  trs "HASH TREE ROOT FOR ", name(typeof(x)), " = ", "0x", $result

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -520,8 +520,7 @@ func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
   if lastCorrectedByte == byte(1):
     if totalBytes == 1:
       # This is an empty bit list.
-      # It should be hashed as a tree containing all zeros:
-      return zeroHashes[merkleizer.topIndex]
+      return getFinalHash(merkleizer)
 
     totalBytes -= 1
     lastCorrectedByte = bytes(x)[^2]

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -518,8 +518,7 @@ func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
     if totalBytes == 1:
       # This is an empty bit list.
       # It should be hashed as a tree containing all zeros:
-      return mergeBranches(zeroHashes[merkleizer.topIndex],
-                           zeroHashes[0]) # this is the mixed length
+      return zeroHashes[merkleizer.topIndex]
 
     totalBytes -= 1
     lastCorrectedByte = bytes(x)[^2]
@@ -552,8 +551,7 @@ func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
   lastChunk[bytesInLastChunk - 1] = lastCorrectedByte
 
   addChunk(merkleizer, lastChunk.toOpenArray(0, bytesInLastChunk - 1))
-  let contentsHash = getFinalHash(merkleizer)
-  mixInLength contentsHash, x.len
+  getFinalHash(merkleizer)
 
 func maxChunksCount(T: type, maxLen: Limit): Limit =
   when T is BitList|BitArray:
@@ -611,7 +609,8 @@ func hashTreeRootList(x: List|BitList): Digest =
   var merkleizer = createMerkleizer(limit)
 
   when x is BitList:
-    bitListHashTreeRoot(merkleizer, BitSeq x)
+    let contentsHash = bitListHashTreeRoot(merkleizer, BitSeq x)
+    mixInLength(contentsHash, x.len)
   else:
     type E = ElemType(T)
     let contentsHash = when E is BasicType:

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -662,6 +662,17 @@ template mergedHash(x: HashArray|HashList, vIdxParam: int64): Digest =
       hashTreeRootCached(x, vIdx),
       hashTreeRootCached(x, vIdx + 1))
 
+func hashTreeRootCached*(x: HashArray, vIdx: int64): Digest =
+  doAssert vIdx >= 1, "Only valid for flat merkle tree indices"
+
+  if not isCached(x.hashes[vIdx]):
+    # TODO oops. so much for maintaining non-mutability.
+    let px = unsafeAddr x
+
+    px[].hashes[vIdx] = mergedHash(x, vIdx * 2)
+
+  return x.hashes[vIdx]
+
 func hashTreeRootCached*(x: HashList, vIdx: int64): Digest =
   doAssert vIdx >= 1, "Only valid for flat merkle tree indices"
 
@@ -688,17 +699,6 @@ func hashTreeRootCached*(x: HashList, vIdx: int64): Digest =
       trs "CACHED ", layerIdx
 
     x.hashes[layerIdx]
-
-func hashTreeRootCached*(x: HashArray, vIdx: int64): Digest =
-  doAssert vIdx >= 1, "Only valid for flat merkle tree indices"
-
-  if not isCached(x.hashes[vIdx]):
-    # TODO oops. so much for maintaining non-mutability.
-    let px = unsafeAddr x
-
-    px[].hashes[vIdx] = mergedHash(x, vIdx * 2)
-
-  return x.hashes[vIdx]
 
 func hashTreeRootCached*(x: HashArray): Digest =
   hashTreeRootCached(x, 1) # Array does not use idx 0

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -556,7 +556,7 @@ func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
   getFinalHash(merkleizer)
 
 func maxChunksCount(T: type, maxLen: Limit): Limit =
-  when T is BitList|BitArray:
+  when T is BitArray|BitList:
     (maxLen + bitsPerChunk - 1) div bitsPerChunk
   elif T is array|List:
     maxChunkIdx(ElemType(T), maxLen)
@@ -616,7 +616,7 @@ func hashTreeRootList(x: List|BitList): Digest =
     let contentsHash = chunkedHashTreeRoot(merkleizer, asSeq x)
     mixInLength(contentsHash, x.len)
 
-func mergedDataHash(x: HashList|HashArray, chunkIdx: int64): Digest =
+func mergedDataHash(x: HashArray|HashList, chunkIdx: int64): Digest =
   # The merged hash of the data at `chunkIdx` and `chunkIdx + 1`
   trs "DATA HASH ", chunkIdx, " ", x.data.len
 
@@ -651,7 +651,7 @@ func mergedDataHash(x: HashList|HashArray, chunkIdx: int64): Digest =
         hash_tree_root(x.data[chunkIdx]),
         hash_tree_root(x.data[chunkIdx + 1]))
 
-template mergedHash(x: HashList|HashArray, vIdxParam: int64): Digest =
+template mergedHash(x: HashArray|HashList, vIdxParam: int64): Digest =
   # The merged hash of the data at `vIdx` and `vIdx + 1`
   let vIdx = vIdxParam
   if vIdx >= x.maxChunks:

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -578,8 +578,8 @@ func hashTreeRootAux[T](x: T): Digest =
     hashTreeRootAux(x.bytes)
   elif T is BitList:
     const totalChunks = maxChunksCount(T, x.maxLen)
-    let contentsHash = bitListHashTreeRoot(totalChunks, BitSeq x)
-    mixInLength(contentsHash, x.len)
+    bitListHashTreeRoot(totalChunks, BitSeq x)
+      .mixInLength(x.len)
   elif T is array:
     type E = ElemType(T)
     when E is BasicType and sizeof(T) <= sizeof(result.data):
@@ -596,8 +596,8 @@ func hashTreeRootAux[T](x: T): Digest =
       chunkedHashTreeRoot(totalChunks, x)
   elif T is List:
     const totalChunks = maxChunksCount(T, x.maxLen)
-    let contentsHash = chunkedHashTreeRoot(totalChunks, asSeq x)
-    mixInLength(contentsHash, x.len)
+    chunkedHashTreeRoot(totalChunks, asSeq x)
+      .mixInLength(x.len)
   elif T is SingleMemberUnion:
     doAssert x.selector == 0'u8
     merkleizeFields(Limit 2):
@@ -710,7 +710,8 @@ func hashTreeRootCached*(x: HashList): Digest =
     if not isCached(x.hashes[0]):
       # TODO oops. so much for maintaining non-mutability.
       let px = unsafeAddr x
-      px[].hashes[0] = mixInLength(hashTreeRootCached(x, 1), x.data.len)
+      px[].hashes[0] = hashTreeRootCached(x, 1)
+        .mixInLength(x.data.len)
 
     x.hashes[0]
 

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -445,8 +445,8 @@ func mixInLength*(root: Digest, length: int): Digest =
 
 func hash_tree_root*(x: auto): Digest {.gcsafe, raises: [Defect].}
 
-template merkleizeFields(totalElements: static Limit, body: untyped): Digest =
-  var merkleizer {.inject.} = createMerkleizer(totalElements)
+template merkleizeFields(totalChunks: static Limit, body: untyped): Digest =
+  var merkleizer {.inject.} = createMerkleizer(totalChunks)
 
   template addField(field) =
     let hash = hash_tree_root(field)
@@ -596,9 +596,9 @@ func hashTreeRootAux[T](x: T): Digest =
     #   # TODO: Need to implement this for case object (SSZ Union)
     #   unsupported T
     trs "MERKLEIZING FIELDS"
-    const totalFields = when T is array: len(x)
+    const totalChunks = when T is array: len(x)
                         else: totalSerializedFields(T)
-    merkleizeFields(Limit totalFields):
+    merkleizeFields(Limit totalChunks):
       x.enumerateSubFields(f):
         addField f
   else:

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -571,6 +571,8 @@ func hashTreeRootAux[T](x: T): Digest =
       result.data[0..<sizeof(x)] = toBytesLE(x)
     else:
       copyMem(addr result.data[0], unsafeAddr x, sizeof x)
+  elif T is BitArray:
+    hashTreeRootAux(x.bytes)
   elif T is array:
     type E = ElemType(T)
     when E is BasicType and sizeof(T) <= sizeof(result.data):
@@ -585,8 +587,6 @@ func hashTreeRootAux[T](x: T): Digest =
       trs "FIXED TYPE; USE CHUNK STREAM"
       var merkleizer = createMerkleizer(maxChunksCount(T, Limit x.len))
       chunkedHashTreeRoot(merkleizer, x)
-  elif T is BitArray:
-    hashTreeRootAux(x.bytes)
   elif T is SingleMemberUnion:
     doAssert x.selector == 0'u8
     merkleizeFields(Limit 2):

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -726,6 +726,6 @@ func hash_tree_root*(x: auto): Digest =
     elif x is List|BitList:
       hashTreeRootList(x)
     else:
-      hashTreeRootAux toSszType(x)
+      hashTreeRootAux(toSszType(x))
 
   trs "HASH TREE ROOT FOR ", name(typeof(x)), " = ", "0x", $result

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -716,7 +716,7 @@ func hashTreeRootCached*(x: HashList): Digest =
     x.hashes[0]
 
 func hash_tree_root*(x: auto): Digest =
-  trs "STARTING HASH TREE ROOT FOR TYPE ", name(typeof(x))
+  trs "STARTING HASH TREE ROOT FOR TYPE ", typeof(x).name
   mixin toSszType
 
   result =
@@ -725,4 +725,4 @@ func hash_tree_root*(x: auto): Digest =
     else:
       hashTreeRootAux(toSszType(x))
 
-  trs "HASH TREE ROOT FOR ", name(typeof(x)), " = ", "0x", $result
+  trs "HASH TREE ROOT FOR ", typeof(x).name, " = ", "0x", $result


### PR DESCRIPTION
Instead of passing a merkleizer into the SSZ serialization functions,
they now allocate the merkleizer themselves. This makes it easier to
re-use those functions in future code (e.g., merkle multiproof code).