### PR TITLE
`int` -> `int64` fix in `hashTreeRootCached`

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -696,7 +696,7 @@ func hashTreeRootCached*(x: HashList, vIdx: int64): Digest =
 
     x.hashes[layerIdx]
 
-func hashTreeRootCached*(x: HashArray, vIdx: int): Digest =
+func hashTreeRootCached*(x: HashArray, vIdx: int64): Digest =
   doAssert vIdx >= 1, "Only valid for flat merkle tree indices"
 
   if not isCached(x.hashes[vIdx]):


### PR DESCRIPTION
Corrects an incorrect `int` width in `hashTreeRootCached` on platforms
with 32-bit `int`. Unlikely to have been hit in practice.