### PR TITLE
Use `uint64` for `GeneralizedIndex`

### DIFF
--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -14,8 +14,6 @@ import
 
 export merkleization
 
-type GeneralizedIndex* = uint64
-
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/sync-protocol.md#get_subtree_index
 func get_subtree_index*(idx: GeneralizedIndex): uint64 =
   doAssert idx > 0

--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -14,9 +14,7 @@ import
 
 export merkleization
 
-# TODO Figure out what would be the right type for this.
-#      It probably fits in uint16 for all practical purposes.
-type GeneralizedIndex* = uint32
+type GeneralizedIndex* = uint64
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/sync-protocol.md#get_subtree_index
 func get_subtree_index*(idx: GeneralizedIndex): uint64 =

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -23,9 +23,7 @@ const
   bytesPerChunk* = 32
 
 type
-  # TODO Figure out what would be the right type for this.
-  #      It probably fits in uint16 for all practical purposes.
-  GeneralizedIndex* = uint32
+  GeneralizedIndex* = uint64
 
   UintN* = SomeUnsignedInt|UInt128|UInt256
   BasicType* = bool|UintN


### PR DESCRIPTION
To support adressing any nimbus-eth2 `BeaconState` member, 32-bit wide
indices are not enough. `BeaconState` requires 5 levels of depth;
`VALIDATOR_REGISTRY_LIMIT` for the `validators` array requires 40 levels
for the contents plus 2 levels for `len` and the root. Another 4 levels
are required for `Validator`. This means that 52-bit indices are needed.
Extending to `uint64` should provide enough leeway without requiring
further implementation adjustments.