### PR TITLE
Add support for building merkle multiproofs

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -1,5 +1,5 @@
 # ssz_serialization
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,7 +12,8 @@
 {.push raises: [Defect].}
 
 import
-  stew/[bitops2, endians2, ptrops],
+  std/[algorithm, sequtils],
+  stew/[bitops2, endians2, ptrops, results],
   stew/ranges/ptr_arith, nimcrypto/[hash, sha2],
   serialization/testing/tracing,
   "."/[bitseqs, codec, types]
@@ -29,6 +30,7 @@ else:
   const USE_BLST_SHA256 = false
 
 export
+  results,
   sha2.update, hash.fromHex,
   codec, bitseqs, types
 
@@ -403,13 +405,14 @@ template totalChunks*(merkleizer: SszMerkleizer): uint64 =
 template getFinalHash*(merkleizer: SszMerkleizer): Digest =
   merkleizer.impl.getFinalHash
 
-template createMerkleizer*(totalElements: static Limit): SszMerkleizerImpl =
-  trs "CREATING A MERKLEIZER FOR ", totalElements
+template createMerkleizer*(
+    totalElements: static Limit, topLayer = 0): SszMerkleizerImpl =
+  trs "CREATING A MERKLEIZER FOR ", totalElements, " (topLayer: ", topLayer, ")"
 
   const treeHeight = binaryTreeHeight totalElements
   var combinedChunks {.noInit.}: array[treeHeight, Digest]
 
-  let topIndex = treeHeight - 1
+  let topIndex = treeHeight - 1 - topLayer
 
   SszMerkleizerImpl(
     combinedChunks: cast[ptr UncheckedArray[Digest]](addr combinedChunks),
@@ -462,14 +465,22 @@ func mixInLength*(root: Digest, length: int): Digest =
 
 func hash_tree_root*(x: auto): Digest {.gcsafe, raises: [Defect].}
 
+func hash_tree_root_multi(
+    x: auto,
+    indices: openArray[GeneralizedIndex],
+    roots: var openArray[Digest],
+    loopOrder: seq[int],
+    slice: Slice[int],
+    atLayer = 0): Result[void, string] {.gcsafe, raises: [Defect].}
+
+template addField(field) =
+  let hash = hash_tree_root(field)
+  trs "MERKLEIZING FIELD ", astToStr(field), " = ", hash
+  addChunk(merkleizer, hash.data)
+  trs "CHUNK ADDED"
+
 template merkleizeFields(totalChunks: static Limit, body: untyped): Digest =
   var merkleizer {.inject.} = createMerkleizer(totalChunks)
-
-  template addField(field) =
-    let hash = hash_tree_root(field)
-    trs "MERKLEIZING FIELD ", astToStr(field), " = ", hash
-    addChunk(merkleizer, hash.data)
-    trs "CHUNK ADDED"
 
   body
 
@@ -481,17 +492,15 @@ template writeBytesLE(chunk: var array[bytesPerChunk, byte], atParam: int,
   chunk[at ..< at + sizeof(val)] = toBytesLE(val)
 
 func chunkedHashTreeRoot[T: BasicType](
-    merkleizer: var SszMerkleizerImpl, arr: openArray[T]): Digest =
+    merkleizer: var SszMerkleizerImpl, arr: openArray[T],
+    firstIdx, numFromFirst: Limit): Digest =
   static:
     doAssert bytesPerChunk mod sizeof(T) == 0
 
-  if arr.len == 0:
-    return getFinalHash(merkleizer)
-
   when sizeof(T) == 1 or cpuEndian == littleEndian:
     var
-      remainingBytes = arr.len * sizeof(T)
-      pos = cast[ptr byte](unsafeAddr arr[0])
+      remainingBytes = numFromFirst * sizeof(T)
+      pos = cast[ptr byte](unsafeAddr arr[firstIdx])
 
     while remainingBytes >= bytesPerChunk:
       addChunk(merkleizer, makeOpenArray(pos, bytesPerChunk))
@@ -499,37 +508,66 @@ func chunkedHashTreeRoot[T: BasicType](
       remainingBytes -= bytesPerChunk
 
     if remainingBytes > 0:
-      addChunk(merkleizer, makeOpenArray(pos, remainingBytes))
-
+      addChunk(merkleizer, makeOpenArray(pos, remainingBytes.int))
   else:
     const valuesPerChunk = bytesPerChunk div sizeof(T)
 
     var writtenValues = 0
 
     var chunk: array[bytesPerChunk, byte]
-    while writtenValues < arr.len - valuesPerChunk:
+    while writtenValues < numFromFirst - valuesPerChunk:
       for i in 0 ..< valuesPerChunk:
-        chunk.writeBytesLE(i * sizeof(T), arr[writtenValues + i])
+        chunk.writeBytesLE(i * sizeof(T), arr[firstIdx + writtenValues + i])
       addChunk(merkleizer, chunk)
       inc writtenValues, valuesPerChunk
 
-    let remainingValues = arr.len - writtenValues
+    let remainingValues = numFromFirst - writtenValues
     if remainingValues > 0:
       var lastChunk: array[bytesPerChunk, byte]
       for i in 0 ..< remainingValues:
-        lastChunk.writeBytesLE(i * sizeof(T), arr[writtenValues + i])
+        lastChunk.writeBytesLE(i * sizeof(T), arr[firstIdx + writtenValues + i])
       addChunk(merkleizer, lastChunk)
 
   getFinalHash(merkleizer)
 
 template chunkedHashTreeRoot[T: not BasicType](
-    merkleizer: var SszMerkleizerImpl, arr: openArray[T]): Digest =
-  for elem in arr:
-    let elemHash = hash_tree_root(elem)
+    merkleizer: var SszMerkleizerImpl, arr: openArray[T],
+    firstIdx, numFromFirst: Limit): Digest =
+  for i in 0 ..< numFromFirst:
+    let elemHash = hash_tree_root(arr[firstIdx + i])
     addChunk(merkleizer, elemHash.data)
   getFinalHash(merkleizer)
 
-func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
+template chunkedHashTreeRoot[T](
+    totalChunks: static Limit, arr: openArray[T],
+    chunks: Slice[Limit], topLayer: int): Digest =
+  const valuesPerChunk =
+    when T is BasicType:
+      bytesPerChunk div sizeof(T)
+    else:
+      1
+  let firstIdx = chunks.a * valuesPerChunk
+  if arr.len <= firstIdx:
+    const treeHeight = binaryTreeHeight totalChunks
+    zeroHashes[treeHeight - 1 - topLayer]
+  else:
+    var merkleizer = createMerkleizer(totalChunks, topLayer)
+    let numFromFirst =
+      min((chunks.b - chunks.a + 1) * valuesPerChunk, arr.len - firstIdx)
+    chunkedHashTreeRoot(merkleizer, arr, firstIdx, numFromFirst)
+
+template chunkedHashTreeRoot[T](
+    totalChunks: static Limit, arr: openArray[T]): Digest =
+  if arr.len <= 0:
+    const treeHeight = binaryTreeHeight totalChunks
+    zeroHashes[treeHeight - 1]
+  else:
+    var merkleizer = createMerkleizer(totalChunks)
+    chunkedHashTreeRoot(merkleizer, arr, 0, arr.len)
+
+func bitListHashTreeRoot(
+    merkleizer: var SszMerkleizerImpl, x: BitSeq,
+    chunks: Slice[Limit]): Digest =
   # TODO: Switch to a simpler BitList representation and
   #       replace this with `chunkedHashTreeRoot`
   var
@@ -540,8 +578,7 @@ func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
     if totalBytes == 1:
       # This is an empty bit list.
       # It should be hashed as a tree containing all zeros:
-      return mergeBranches(zeroHashes[merkleizer.topIndex],
-                           zeroHashes[0]) # this is the mixed length
+      return zeroHashes[merkleizer.topIndex]
 
     totalBytes -= 1
     lastCorrectedByte = bytes(x)[^2]
@@ -557,25 +594,36 @@ func bitListHashTreeRoot(merkleizer: var SszMerkleizerImpl, x: BitSeq): Digest =
     fullChunks -= 1
     bytesInLastChunk = 32
 
-  for i in 0 ..< fullChunks:
+  for i in chunks.a .. min(chunks.b, fullChunks - 1):
     let
-      chunkStartPos = i * bytesPerChunk
+      chunkStartPos = i.int * bytesPerChunk
       chunkEndPos = chunkStartPos + bytesPerChunk - 1
 
     addChunk(merkleizer, bytes(x).toOpenArray(chunkStartPos, chunkEndPos))
 
-  var
-    lastChunk: array[bytesPerChunk, byte]
-    chunkStartPos = fullChunks * bytesPerChunk
+  if fullChunks in chunks:
+    var
+      lastChunk: array[bytesPerChunk, byte]
+      chunkStartPos = fullChunks * bytesPerChunk
 
-  for i in 0 .. bytesInLastChunk - 2:
-    lastChunk[i] = bytes(x)[chunkStartPos + i]
+    for i in 0 .. bytesInLastChunk - 2:
+      lastChunk[i] = bytes(x)[chunkStartPos + i]
 
-  lastChunk[bytesInLastChunk - 1] = lastCorrectedByte
+    lastChunk[bytesInLastChunk - 1] = lastCorrectedByte
 
-  addChunk(merkleizer, lastChunk.toOpenArray(0, bytesInLastChunk - 1))
-  let contentsHash = getFinalHash(merkleizer)
-  mixInLength contentsHash, x.len
+    addChunk(merkleizer, lastChunk.toOpenArray(0, bytesInLastChunk - 1))
+
+  getFinalHash(merkleizer)
+
+template bitListHashTreeRoot(
+    totalChunks: static Limit, x: BitSeq,
+    chunks: Slice[Limit], topLayer: int): Digest =
+  var merkleizer = createMerkleizer(totalChunks, topLayer)
+  bitListHashTreeRoot(merkleizer, x, chunks)
+
+template bitListHashTreeRoot(
+    totalChunks: static Limit, x: BitSeq): Digest =
+  bitListHashTreeRoot(totalChunks, x, 0.Limit ..< totalChunks, topLayer = 0)
 
 func maxChunksCount(T: type, maxLen: Limit): Limit =
   when T is BitArray|BitList:
@@ -584,6 +632,47 @@ func maxChunksCount(T: type, maxLen: Limit): Limit =
     maxChunkIdx(ElemType(T), maxLen)
   else:
     unsupported T # This should never happen
+
+template chunkForIndex(chunkIndex: GeneralizedIndex): Limit =
+  block:
+    (chunkIndex - firstChunkIndex).Limit
+
+template chunksForIndex(index: GeneralizedIndex): Slice[Limit] =
+  block:
+    let
+      numLayersAboveChunks = chunkLayer - indexLayer
+      chunkIndexLow = index shl numLayersAboveChunks
+      chunkIndexHigh = chunkIndexLow or
+        ((1.GeneralizedIndex shl numLayersAboveChunks) - 1.GeneralizedIndex)
+
+    chunkForIndex(chunkIndexLow) .. chunkForIndex(chunkIndexHigh)
+
+template chunkContainingIndex(indexParam: GeneralizedIndex): Limit =
+  block:
+    let
+      index = indexParam
+      indexLayer = log2trunc(index)
+      numLayersBelowChunks = indexLayer - chunkLayer
+      chunkIndex = index shr numLayersBelowChunks
+
+    chunkForIndex(chunkIndex).Limit
+
+template indexAt(i: int): GeneralizedIndex =
+  block:
+    let v = indices[loopOrder[i]]
+    if atLayer != 0:
+      let
+        n = leadingZeros(v) + 1 + atLayer
+        x = ((v shl n) or 1.GeneralizedIndex).GeneralizedIndex
+      rotateRight(x, n)
+    else:
+      v
+
+template rootAt(i: int): Digest =
+  roots[loopOrder[i]]
+
+const unsupportedIndex =
+  err(Result[void, string], "Generalized index not supported.")
 
 func hashTreeRootAux[T](x: T): Digest =
   when T is bool|char:
@@ -597,8 +686,8 @@ func hashTreeRootAux[T](x: T): Digest =
     hashTreeRootAux(x.bytes)
   elif T is BitList:
     const totalChunks = maxChunksCount(T, x.maxLen)
-    var merkleizer = createMerkleizer(totalChunks)
-    bitListHashTreeRoot(merkleizer, BitSeq x)
+    let contentsHash = bitListHashTreeRoot(totalChunks, BitSeq x)
+    mixInLength(contentsHash, x.len)
   elif T is array:
     type E = ElemType(T)
     when E is BasicType and sizeof(T) <= sizeof(result.data):
@@ -612,12 +701,10 @@ func hashTreeRootAux[T](x: T): Digest =
     else:
       trs "FIXED TYPE; USE CHUNK STREAM"
       const totalChunks = maxChunksCount(T, x.len)
-      var merkleizer = createMerkleizer(totalChunks)
-      chunkedHashTreeRoot(merkleizer, x)
+      chunkedHashTreeRoot(totalChunks, x)
   elif T is List:
     const totalChunks = maxChunksCount(T, x.maxLen)
-    var merkleizer = createMerkleizer(totalChunks)
-    let contentsHash = chunkedHashTreeRoot(merkleizer, asSeq x)
+    let contentsHash = chunkedHashTreeRoot(totalChunks, asSeq x)
     mixInLength(contentsHash, x.len)
   elif T is SingleMemberUnion:
     doAssert x.selector == 0'u8
@@ -634,6 +721,248 @@ func hashTreeRootAux[T](x: T): Digest =
         addField f
   else:
     unsupported T
+
+func hashTreeRootAux[T](
+    x: T,
+    indices: openArray[GeneralizedIndex],
+    roots: var openArray[Digest],
+    loopOrder: seq[int],
+    slice: Slice[int],
+    atLayer: int): Result[void, string] =
+  when T is BasicType:
+    for i in slice:
+      if indexAt(i) != 1.GeneralizedIndex: return unsupportedIndex
+      rootAt(i) = hashTreeRootAux(x)
+  elif T is BitArray:
+    ? hashTreeRootAux(x.bytes, indices, roots, loopOrder, slice, atLayer)
+  elif T is BitList:
+    const
+      totalChunks = maxChunksCount(T, x.maxLen)
+      firstChunkIndex = nextPow2(totalChunks.uint64)
+      chunkLayer = log2trunc(firstChunkIndex)
+    var i = slice.a
+    while i <= slice.b:
+      let
+        index = indexAt(i)
+        indexLayer = log2trunc(index)
+      if index == 1.GeneralizedIndex:
+        let contentsHash = bitListHashTreeRoot(totalChunks, BitSeq x)
+        rootAt(i) = mixInLength(contentsHash, x.len)
+        inc i
+      elif index == 3.GeneralizedIndex:
+        rootAt(i) = hashTreeRootAux(x.len.uint64)
+        inc i
+      elif index == 2.GeneralizedIndex:
+        rootAt(i) = bitListHashTreeRoot(totalChunks, BitSeq x)
+        inc i
+      elif (index shr (indexLayer - 1)) == 2.GeneralizedIndex:
+        let
+          atLayer = atLayer + 1
+          index = indexAt(i)
+          indexLayer = log2trunc(index)
+        if indexLayer <= chunkLayer:
+          let chunks = chunksForIndex(index)
+          rootAt(i) = bitListHashTreeRoot(totalChunks, BitSeq x,
+                                          chunks, indexLayer)
+          inc i
+        else: return unsupportedIndex
+      else: return unsupportedIndex
+  elif T is array:
+    type E = ElemType(T)
+    when E is BasicType and sizeof(T) <= sizeof(roots[0].data):
+      for i in slice:
+        if indexAt(i) != 1.GeneralizedIndex: return unsupportedIndex
+        rootAt(i) = hashTreeRootAux(x)
+    else:
+      trs "FIXED TYPE; USE CHUNK STREAM"
+      const
+        totalChunks = maxChunksCount(T, x.len)
+        firstChunkIndex = nextPow2(totalChunks.uint64)
+        chunkLayer = log2trunc(firstChunkIndex)
+      var i = slice.a
+      while i <= slice.b:
+        let
+          index = indexAt(i)
+          indexLayer = log2trunc(index)
+        if index == 1.GeneralizedIndex:
+          rootAt(i) = chunkedHashTreeRoot(totalChunks, x)
+          inc i
+        elif indexLayer <= chunkLayer:
+          let chunks = chunksForIndex(index)
+          rootAt(i) = chunkedHashTreeRoot(totalChunks, x,
+                                          chunks, indexLayer)
+          inc i
+        else:
+          when ElemType(typeof(x)) is BasicType: return unsupportedIndex
+          else:
+            let chunk = chunkContainingIndex(index)
+            if chunk >= x.len: return unsupportedIndex
+            var j = i + 1
+            while j <= slice.b and
+                chunkContainingIndex(indexAt(j)) == chunk:
+              inc j
+            ? hash_tree_root_multi(x[chunk], indices, roots, loopOrder, i ..< j,
+                                   atLayer + chunkLayer)
+            i = j
+  elif T is List:
+    const
+      totalChunks = maxChunksCount(T, x.maxLen)
+      firstChunkIndex = nextPow2(totalChunks.uint64)
+      chunkLayer = log2trunc(firstChunkIndex)
+    var i = slice.a
+    while i <= slice.b:
+      let
+        index = indexAt(i)
+        indexLayer = log2trunc(index)
+      if index == 1.GeneralizedIndex:
+        let contentsHash = chunkedHashTreeRoot(totalChunks, asSeq x)
+        rootAt(i) = mixInLength(contentsHash, x.len)
+        inc i
+      elif index == 3.GeneralizedIndex:
+        rootAt(i) = hashTreeRootAux(x.len.uint64)
+        inc i
+      elif index == 2.GeneralizedIndex:
+        rootAt(i) = chunkedHashTreeRoot(totalChunks, asSeq x)
+        inc i
+      elif (index shr (indexLayer - 1)) == 2.GeneralizedIndex:
+        let
+          atLayer = atLayer + 1
+          index = indexAt(i)
+          indexLayer = log2trunc(index)
+        if indexLayer <= chunkLayer:
+          let chunks = chunksForIndex(index)
+          rootAt(i) = chunkedHashTreeRoot(totalChunks, asSeq x,
+                                          chunks, indexLayer)
+          inc i
+        else:
+          when ElemType(typeof(x)) is BasicType: return unsupportedIndex
+          else:
+            let chunk = chunkContainingIndex(index)
+            if chunk >= x.len: return unsupportedIndex
+            var j = i + 1
+            while j <= slice.b and
+                chunkContainingIndex(indexAt(j)) == chunk:
+              inc j
+            ? hash_tree_root_multi(x[chunk], indices, roots, loopOrder, i ..< j,
+                                   atLayer + chunkLayer)
+            i = j
+      else: return unsupportedIndex
+  elif T is SingleMemberUnion:
+    doAssert x.selector == 0'u8
+    const
+      totalChunks = Limit 1
+      firstChunkIndex = nextPow2(totalChunks.uint64)
+      chunkLayer = log2trunc(firstChunkIndex)
+    var i = slice.a
+    while i <= slice.b:
+      let
+        index = indexAt(i)
+        indexLayer = log2trunc(index)
+      if index == 1.GeneralizedIndex:
+        var merkleizer = createMerkleizer(Limit 2)
+        addField hash_tree_root(x.value)
+        rootAt(i) = getFinalHash(merkleizer)
+        inc i
+      elif index == 3.GeneralizedIndex:
+        rootAt(i) = Digest()
+        inc i
+      elif index == 2.GeneralizedIndex:
+        rootAt(i) = hash_tree_root(x.value)
+        inc i
+      elif (index shr (indexLayer - 1)) == 2.GeneralizedIndex:
+        let
+          atLayer = atLayer + 1
+          index = indexAt(i)
+          chunk = chunkContainingIndex(index)
+        var j = i + 1
+        while j <= slice.b and
+            chunkContainingIndex(indexAt(j)) == chunk:
+          inc j
+        ? hash_tree_root_multi(x.value, indices, roots, loopOrder, i ..< j,
+                               atLayer + chunkLayer)
+        i = j
+      else: return unsupportedIndex
+  elif T is object|tuple:
+    # when T.isCaseObject():
+    #   # TODO: Need to implement this for case object (SSZ Union)
+    #   unsupported T
+    trs "MERKLEIZING FIELDS"
+    const
+      totalChunks = totalSerializedFields(T)
+      firstChunkIndex = nextPow2(totalChunks.uint64)
+      chunkLayer = log2trunc(firstChunkIndex)
+    var
+      combinedChunks {.noInit.}: array[chunkLayer + 1, Digest]
+      i = slice.a
+      fieldIndex = 0.Limit
+      isActive = false
+      index {.noinit.}: GeneralizedIndex
+      indexLayer {.noinit.}: int
+      chunks {.noinit.}: Slice[Limit]
+      merkleizer {.noinit.}: SszMerkleizerImpl
+      chunk {.noinit.}: Limit
+      nextField {.noinit.}: Limit
+    x.enumerateSubFields(f):
+      if i <= slice.b:
+        if not isActive:
+          index = indexAt(i)
+          indexLayer = log2trunc(index)
+          nextField =
+            if indexLayer == chunkLayer:
+              chunkForIndex(index)
+            elif indexLayer < chunkLayer:
+              chunks = chunksForIndex(index)
+              merkleizer = SszMerkleizerImpl(
+                combinedChunks:
+                  cast[ptr UncheckedArray[Digest]](addr combinedChunks),
+                topIndex: chunkLayer - indexLayer)
+              chunks.a
+            else:
+              chunk = chunkContainingIndex(index)
+              chunk
+          isActive = true
+        if fieldIndex >= nextField:
+          if indexLayer == chunkLayer:
+            rootAt(i) = hash_tree_root(f)
+            inc i
+            isActive = false
+          elif indexLayer < chunkLayer:
+            addField f
+            if fieldIndex >= chunks.b:
+              rootAt(i) = getFinalHash(merkleizer)
+              inc i
+              isActive = false
+          else:
+            var j = i + 1
+            while j <= slice.b and
+                chunkContainingIndex(indexAt(j)) == chunk:
+              inc j
+            ? hash_tree_root_multi(f, indices, roots, loopOrder, i ..< j,
+                                   atLayer + chunkLayer)
+            i = j
+            isActive = false
+      inc fieldIndex
+    doAssert log2trunc(fieldIndex.uint64) == log2trunc(totalChunks.uint64)
+    while i <= slice.b:
+      index = indexAt(i)
+      indexLayer = log2trunc(index)
+      if indexLayer == chunkLayer:
+        rootAt(i) = static(Digest())
+        inc i
+        isActive = false
+      elif indexLayer < chunkLayer:
+        if not isActive:
+          merkleizer = SszMerkleizerImpl(
+            combinedChunks:
+              cast[ptr UncheckedArray[Digest]](addr combinedChunks),
+            topIndex: chunkLayer - indexLayer)
+        rootAt(i) = getFinalHash(merkleizer)
+        inc i
+        isActive = false
+      else: return unsupportedIndex
+  else:
+    unsupported T
+  ok()
 
 func mergedDataHash(x: HashArray|HashList, chunkIdx: int64): Digest =
   # The merged hash of the data at `chunkIdx` and `chunkIdx + 1`
@@ -735,6 +1064,101 @@ func hashTreeRootCached*(x: HashList): Digest =
 
     x.hashes[0]
 
+func hashTreeRootCached*(
+    x: HashArray,
+    indices: openArray[GeneralizedIndex],
+    roots: var openArray[Digest],
+    loopOrder: seq[int],
+    slice: Slice[int],
+    atLayer: int): Result[void, string] =
+  const
+    totalChunks = x.maxChunks
+    firstChunkIndex = nextPow2(totalChunks.uint64)
+    chunkLayer = log2trunc(firstChunkIndex)
+  var i = slice.a
+  while i <= slice.b:
+    let
+      index = indexAt(i)
+      indexLayer = log2trunc(index)
+    if index == 1.GeneralizedIndex:
+      rootAt(i) = hashTreeRootCached(x)
+      inc i
+    elif indexLayer == chunkLayer:
+      let chunks = chunksForIndex(index)
+      rootAt(i) = chunkedHashTreeRoot(totalChunks, x.data,
+                                      chunks, indexLayer)
+      inc i
+    elif indexLayer < chunkLayer:
+      rootAt(i) = hashTreeRootCached(x, index.int64)
+      inc i
+    else:
+      when ElemType(typeof(x)) is BasicType:
+        return unsupportedIndex
+      else:
+        let chunk = chunkContainingIndex(index)
+        if chunk >= x.len: return unsupportedIndex
+        var j = i + 1
+        while j <= slice.b and
+            chunkContainingIndex(indexAt(j)) == chunk:
+          inc j
+        ? hash_tree_root_multi(x[chunk], indices, roots, loopOrder, i ..< j,
+                               atLayer + chunkLayer)
+        i = j
+  ok()
+
+func hashTreeRootCached*(
+    x: HashList,
+    indices: openArray[GeneralizedIndex],
+    roots: var openArray[Digest],
+    loopOrder: seq[int],
+    slice: Slice[int],
+    atLayer: int): Result[void, string] =
+  const
+    totalChunks = x.maxChunks
+    firstChunkIndex = nextPow2(totalChunks.uint64)
+    chunkLayer = log2trunc(firstChunkIndex)
+  var i = slice.a
+  while i <= slice.b:
+    let
+      index = indexAt(i)
+      indexLayer = log2trunc(index)
+    if index == 1.GeneralizedIndex:
+      rootAt(i) = hashTreeRootCached(x)
+      inc i
+    elif index == 3.GeneralizedIndex:
+      rootAt(i) = hashTreeRootAux(x.len.uint64)
+      inc i
+    elif index == 2.GeneralizedIndex:
+      rootAt(i) = hashTreeRootCached(x, 1)
+      inc i
+    elif (index shr (indexLayer - 1)) == 2.GeneralizedIndex:
+      let
+        atLayer = atLayer + 1
+        index = indexAt(i)
+        indexLayer = log2trunc(index)
+      if indexLayer == chunkLayer:
+        let chunks = chunksForIndex(index)
+        rootAt(i) = chunkedHashTreeRoot(totalChunks, asSeq x.data,
+                                        chunks, indexLayer)
+        inc i
+      elif indexLayer < chunkLayer:
+        rootAt(i) = hashTreeRootCached(x, index.int64)
+        inc i
+      else:
+        when ElemType(typeof(x)) is BasicType: return unsupportedIndex
+        else:
+          let chunk = chunkContainingIndex(index)
+          if chunk >= x.len: return unsupportedIndex
+          var j = i + 1
+          while j <= slice.b and
+              chunkContainingIndex(indexAt(j)) == chunk:
+            inc j
+          ? hash_tree_root_multi(x[chunk], indices, roots, loopOrder, i ..< j,
+                                 atLayer + chunkLayer)
+          i = j
+    else: return unsupportedIndex
+  ok()
+
 func hash_tree_root*(x: auto): Digest =
   trs "STARTING HASH TREE ROOT FOR TYPE ", name(typeof(x))
   mixin toSszType
@@ -746,3 +1170,218 @@ func hash_tree_root*(x: auto): Digest =
       hashTreeRootAux(toSszType(x))
 
   trs "HASH TREE ROOT FOR ", name(typeof(x)), " = ", "0x", $result
+
+# Note: If this function is also called `hash_tree_root`, the Nim compiler may
+# produce incorrect code when calling it, e.g., when called by this overload:
+#   func hash_tree_root*(
+#       x: auto,
+#       indices: static openArray[GeneralizedIndex],
+#       roots: var openArray[Digest]): Result[void, string]
+#
+# Instead of passing the static `indices` to this function, the Nim compiler
+# generates a copy of `indices` with incorrect types (pointers instead of NU64).
+# This copy is then passed to this function which then interprets it as NU64[].
+# On 32-bit platforms such as i386 the pointer width does not match NU64 width,
+# leading to incorrect followup computations and out-of-bounds memory access.
+#
+# Creating a minimal reproducible example showcasing this bug proved difficult.
+#
+# Affected: Nim Compiler Version 1.2.14 [Linux: i386]
+# https://github.com/nim-lang/Nim/issues/19157
+func hash_tree_root_multi(
+    x: auto,
+    indices: openArray[GeneralizedIndex],
+    roots: var openArray[Digest],
+    loopOrder: seq[int],
+    slice: Slice[int],
+    atLayer = 0): Result[void, string] =
+  trs "STARTING HASH TREE ROOT FOR TYPE ", name(typeof(x)),
+    slice.mapIt(indexAt(it))
+  mixin toSszType
+
+  when x is HashArray|HashList:
+    ? hashTreeRootCached(x, indices, roots, loopOrder, slice, atLayer)
+  else:
+    ? hashTreeRootAux(toSszType(x), indices, roots, loopOrder, slice, atLayer)
+
+  trs "HASH TREE ROOT FOR ", name(typeof(x)),
+    slice.mapIt(indexAt(it)), " = ", slice.mapIt("0x" & $rootAt(it))
+  ok()
+
+template normalize(v: GeneralizedIndex): GeneralizedIndex =
+  # GeneralizedIndex is 1-based.
+  # Looking at their bit patterns, from MSB to LSB, they:
+  # - Start with a 1 bit.
+  # - Continue with a 0 bit when going left or 1 bit when going right,
+  #   from the tree root down to the leaf.
+  # i.e., 0b1_110 is the node after picking right branch twice, then left.
+  #
+  # For depth-first ordering, shorter bit-strings are parents of nodes
+  # that include them as their prefix.
+  # i.e., 0b1_110 is parent of 0b1_1100 (left) and 0b1_1101 (right)
+  # An extra 1 bit is added to distinguish parents from their left child.
+  ((v shl 1) or 1) shl leadingZeros(v)
+
+# Comparison utility for sorting indices in depth-first order (in-order).
+# This order is needed because `enumInstanceSerializedFields` does not allow
+# random access to specific fields. With depth-first order only a single pass
+# is required to fill in all the roots. `enumAllSerializedFields` cannot be
+# used for pre-computation at compile time, because the generalized indices
+# depend on the specific case values defined by the specific object instance.
+proc cmpDepthFirst(x, y: GeneralizedIndex): int =
+  cmp(x.normalize, y.normalize)
+
+func merkleizationLoopOrderNimvm(
+    indices: openArray[GeneralizedIndex]): seq[int] {.compileTime.} =
+  result = toSeq(indices.low .. indices.high)
+  let idx = toSeq(indices)
+  result.sort do (x, y: int) -> int:
+    cmpDepthFirst(idx[x], idx[y])
+
+func merkleizationLoopOrderRegular(
+    indices: openArray[GeneralizedIndex]): seq[int] =
+  result = toSeq(indices.low .. indices.high)
+  let idx = cast[ptr UncheckedArray[GeneralizedIndex]](unsafeAddr indices[0])
+  result.sort do (x, y: int) -> int:
+    cmpDepthFirst(idx[x], idx[y])
+
+func merkleizationLoopOrder(
+    indices: openArray[GeneralizedIndex]): seq[int] =
+  when nimvm:
+    merkleizationLoopOrderNimvm(indices)
+  else:
+    merkleizationLoopOrderRegular(indices)
+
+func validateIndices(
+    indices: openArray[GeneralizedIndex],
+    loopOrder: seq[int]): Result[void, string] =
+  var
+    prev = indices[loopOrder[0]]
+    prevLayer = log2trunc(prev)
+  if prev < 1.GeneralizedIndex: return err("Invalid generalized index.")
+  for i in 1 .. loopOrder.high:
+    let
+      curr = indices[loopOrder[i]]
+      currLayer = log2trunc(curr)
+      indicesOverlap =
+        if currLayer < prevLayer:
+          (prev shr (prevLayer - currLayer)) == curr
+        elif currLayer > prevLayer:
+          (curr shr (currLayer - prevLayer)) == prev
+        else:
+          curr == prev
+    if indicesOverlap:
+      return err("Given indices cover some leafs multiple times.")
+    prev = curr
+    prevLayer = currLayer
+  ok()
+
+func hash_tree_root*(
+    x: auto,
+    indices: openArray[GeneralizedIndex],
+    roots: var openArray[Digest]): Result[void, string] =
+  doAssert indices.len == roots.len
+  if indices.len == 0:
+    ok()
+  elif indices.len == 1 and indices[0] == 1.GeneralizedIndex:
+    roots[0] = hash_tree_root(x)
+    ok()
+  else:
+    let loopOrder = merkleizationLoopOrder(indices)
+    ? validateIndices(indices, loopOrder)
+    let slice = 0 ..< loopOrder.len
+    hash_tree_root_multi(x, indices, roots, loopOrder, slice)
+
+func hash_tree_root*(
+    x: auto,
+    indices: static openArray[GeneralizedIndex],
+    roots: var openArray[Digest]): Result[void, string] =
+  doAssert indices.len == roots.len
+  when indices.len == 0:
+    ok()
+  else:
+    when indices.len == 1 and indices[0] == 1.GeneralizedIndex:
+      roots[0] = hash_tree_root(x)
+      ok()
+    else:
+      const
+        loopOrder = merkleizationLoopOrder(indices)
+        v = validateIndices(indices, loopOrder)
+      when v.isErr:
+        err(v.error)
+      else:
+        const slice = 0 ..< loopOrder.len
+        hash_tree_root_multi(x, indices, roots, loopOrder, slice)
+
+func hash_tree_root*(
+    x: auto,
+    indices: openArray[GeneralizedIndex]
+): Result[seq[Digest], string] =
+  if indices.len == 0:
+    ok(newSeq[Digest](0))
+  elif indices.len == 1 and indices[0] == 1.GeneralizedIndex:
+    ok(@[hash_tree_root(x)])
+  else:
+    let loopOrder = merkleizationLoopOrder(indices)
+    ? validateIndices(indices, loopOrder)
+    let slice = 0 ..< loopOrder.len
+    var roots = newSeq[Digest](indices.len)
+    ? hash_tree_root_multi(x, indices, roots, loopOrder, slice)
+    ok(roots)
+
+func hash_tree_root*(
+    x: auto,
+    indices: static openArray[GeneralizedIndex]
+): auto =
+  type ResultType = Result[array[indices.len, Digest], string]
+  when indices.len == 0:
+    ResultType.ok([])
+  else:
+    when indices.len == 1 and indices[0] == 1.GeneralizedIndex:
+      ResultType.ok([hash_tree_root(x)])
+    else:
+      var roots {.noinit.}: array[indices.len, Digest]
+      const
+        loopOrder = merkleizationLoopOrder(indices)
+        v = validateIndices(indices, loopOrder)
+      when v.isErr:
+        ResultType.err(v.error)
+      else:
+        const slice = 0 ..< loopOrder.len
+        let w = hash_tree_root_multi(x, indices, roots, loopOrder, slice)
+        if w.isErr:
+          ResultType.err(w.error)
+        else:
+          ResultType.ok(roots)
+
+func hash_tree_root*(
+    x: auto,
+    index: GeneralizedIndex
+): Result[Digest, string] =
+  if index < 1.GeneralizedIndex:
+    err("Invalid generalized index.")
+  elif index == 1.GeneralizedIndex:
+    ok(hash_tree_root(x))
+  else:
+    const
+      loopOrder = @[0]
+      slice = 0 ..< loopOrder.len
+    var roots {.noinit.}: array[1, Digest]
+    ? hash_tree_root_multi(x, [index], roots, loopOrder, slice)
+    ok(roots[0])
+
+func hash_tree_root*(
+    x: auto,
+    index: static GeneralizedIndex
+): Result[Digest, string] =
+  when index < 1.GeneralizedIndex:
+    err("Invalid generalized index.")
+  elif index == 1.GeneralizedIndex:
+    ok(hash_tree_root(x))
+  else:
+    const
+      loopOrder = @[0]
+      slice = 0 ..< loopOrder.len
+    var roots {.noinit.}: array[1, Digest]
+    ? hash_tree_root_multi(x, [index], roots, loopOrder, slice)
+    ok(roots[0])

--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -14,10 +14,6 @@ import
 
 export merkleization
 
-# TODO Figure out what would be the right type for this.
-#      It probably fits in uint16 for all practical purposes.
-type GeneralizedIndex* = uint32
-
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/sync-protocol.md#get_subtree_index
 func get_subtree_index*(idx: GeneralizedIndex): uint64 =
   doAssert idx > 0
@@ -41,7 +37,7 @@ template generalized_index_parent*(
     index: GeneralizedIndex): GeneralizedIndex =
   index shr 1
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.5/ssz/merkle-proofs.md#merkle-multiproofs
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/ssz/merkle-proofs.md#merkle-multiproofs
 iterator get_branch_indices*(
     tree_index: GeneralizedIndex): GeneralizedIndex =
   ## Get the generalized indices of the sister chunks along the path
@@ -51,7 +47,7 @@ iterator get_branch_indices*(
     yield generalized_index_sibling(index)
     index = generalized_index_parent(index)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.5/ssz/merkle-proofs.md#merkle-multiproofs
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/ssz/merkle-proofs.md#merkle-multiproofs
 iterator get_path_indices*(
     tree_index: GeneralizedIndex): GeneralizedIndex =
   ## Get the generalized indices of the chunks along the path
@@ -63,7 +59,7 @@ iterator get_path_indices*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/ssz/merkle-proofs.md#merkle-multiproofs
 func get_helper_indices*(
-    indices: openArray[GeneralizedIndex]): seq[GeneralizedIndex] =
+    indices: varargs[GeneralizedIndex]): seq[GeneralizedIndex] =
   ## Get the generalized indices of all "extra" chunks in the tree needed
   ## to prove the chunks with the given generalized indices. Note that the
   ## decreasing order is chosen deliberately to ensure equivalence to the order
@@ -82,9 +78,9 @@ func get_helper_indices*(
   res.sort(SortOrder.Descending)
   res
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.5/ssz/merkle-proofs.md#merkle-multiproofs
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/ssz/merkle-proofs.md#merkle-multiproofs
 func check_multiproof_acceptable*(
-    indices: openArray[GeneralizedIndex]): Result[void, string] =
+    indices: varargs[GeneralizedIndex]): Result[void, string] =
   # Check that proof verification won't allocate excessive amounts of memory.
   const max_multiproof_complexity = nextPowerOfTwo(256)
   if indices.len > max_multiproof_complexity:
@@ -92,7 +88,7 @@ func check_multiproof_acceptable*(
 
   if indices.len == 0:
     return err("No indices specified")
-  if indices.anyIt(it == 0.GeneralizedIndex):
+  if indices.anyIt(it <= 0.GeneralizedIndex):
     return err("Invalid index specified")
   ok()
 
@@ -219,8 +215,7 @@ func calculate_multi_merkle_root*(
   if leaves.len != indices.len:
     return err("Length mismatch for leaves and indices")
   ? check_multiproof_acceptable(indices)
-  calculate_multi_merkle_root_impl(
-    leaves, proof, indices, helper_indices)
+  calculate_multi_merkle_root_impl(leaves, proof, indices, helper_indices)
 
 func calculate_multi_merkle_root*(
     leaves: openArray[Digest],
@@ -229,8 +224,18 @@ func calculate_multi_merkle_root*(
   if leaves.len != indices.len:
     return err("Length mismatch for leaves and indices")
   ? check_multiproof_acceptable(indices)
-  calculate_multi_merkle_root_impl(
-    leaves, proof, indices, get_helper_indices(indices))
+  let helper_indices = get_helper_indices(indices)
+  calculate_multi_merkle_root_impl(leaves, proof, indices, helper_indices)
+
+func calculate_multi_merkle_root*(
+    leaves: openArray[Digest],
+    proof: openArray[Digest],
+    indices: static openArray[GeneralizedIndex]): Result[Digest, string] =
+  if leaves.len != indices.len:
+    return err("Length mismatch for leaves and indices")
+  static: ? check_multiproof_acceptable(indices)
+  const helper_indices = get_helper_indices(indices)
+  calculate_multi_merkle_root_impl(leaves, proof, indices, helper_indices)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/ssz/merkle-proofs.md#merkle-multiproofs
 func verify_merkle_multiproof*(
@@ -252,6 +257,106 @@ func verify_merkle_multiproof*(
   if calc.isErr: return false
   calc.get == root
 
+func verify_merkle_multiproof*(
+    leaves: openArray[Digest],
+    proof: openArray[Digest],
+    indices: static openArray[GeneralizedIndex],
+    root: Digest): bool =
+  const helper_indices = get_helper_indices(indices)
+  let calc = calculate_multi_merkle_root(leaves, proof, indices, helper_indices)
+  if calc.isErr: return false
+  calc.get == root
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/tests/core/pyspec/eth2spec/test/helpers/merkle.py#L4-L21
+func build_proof*(
+    anchor: auto,
+    indices: openArray[GeneralizedIndex],
+    helper_indices: openArray[GeneralizedIndex],
+    proof: var openArray[Digest]): Result[void, string] =
+  doAssert proof.len == helper_indices.len
+  ? check_multiproof_acceptable(indices)
+  hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    indices: openArray[GeneralizedIndex],
+    proof: var openArray[Digest]): Result[void, string] =
+  ? check_multiproof_acceptable(indices)
+  let helper_indices = get_helper_indices(indices)
+  doAssert proof.len == helper_indices.len
+  hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    indices: static openArray[GeneralizedIndex],
+    proof: var openArray[Digest]): Result[void, string] =
+  const v = check_multiproof_acceptable(indices)
+  when v.isErr:
+    result.err(v.error)
+  else:
+    const helper_indices = get_helper_indices(indices)
+    doAssert proof.len == helper_indices.len
+    hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    index: GeneralizedIndex,
+    proof: var openArray[Digest]): Result[void, string] =
+  ? check_multiproof_acceptable(index)
+  let helper_indices = get_helper_indices(index)
+  doAssert proof.len == helper_indices.len
+  hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    index: static GeneralizedIndex,
+    proof: var openArray[Digest]): Result[void, string] =
+  const v = check_multiproof_acceptable(index)
+  when v.isErr:
+    result.err(v.error)
+  else:
+    const helper_indices = get_helper_indices(index)
+    doAssert proof.len == helper_indices.len
+    hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    indices: openArray[GeneralizedIndex]
+): Result[seq[Digest], string] =
+  ? check_multiproof_acceptable(indices)
+  let helper_indices = get_helper_indices(indices)
+  hash_tree_root(anchor, helper_indices)
+
+func build_proof*(
+    anchor: auto,
+    indices: static openArray[GeneralizedIndex]
+): auto =
+  const v = check_multiproof_acceptable(indices)
+  when v.isErr:
+    Result[array[0, Digest], string].err(v.error)
+  else:
+    const helper_indices = get_helper_indices(indices)
+    hash_tree_root(anchor, helper_indices)
+
+func build_proof*(
+    anchor: auto,
+    index: GeneralizedIndex
+): Result[seq[Digest], string] =
+  ? check_multiproof_acceptable(index)
+  let helper_indices = get_helper_indices(index)
+  hash_tree_root(anchor, helper_indices)
+
+func build_proof*(
+    anchor: auto,
+    index: static GeneralizedIndex
+): auto =
+  const v = check_multiproof_acceptable(index)
+  when v.isErr:
+    Result[array[0, Digest], string].err(v.error)
+  else:
+    const helper_indices = get_helper_indices(index)
+    hash_tree_root(anchor, helper_indices)
+
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/beacon-chain.md#is_valid_merkle_branch
 func is_valid_merkle_branch*(leaf: Digest, branch: openArray[Digest],
                              depth: int, index: uint64,
@@ -271,56 +376,3 @@ func is_valid_merkle_branch*(leaf: Digest, branch: openArray[Digest],
       buf[32..63] = branch[i].data
     value = digest(buf)
   value == root
-
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/tests/core/pyspec/eth2spec/test/helpers/merkle.py#L4-L21
-func build_proof_impl(anchor: object, leaf_index: uint64,
-                      proof: var openArray[Digest]) =
-  let
-    bottom_length = nextPow2(typeof(anchor).totalSerializedFields.uint64)
-    tree_depth = log2trunc(bottom_length)
-    parent_index =
-      if leaf_index < bottom_length shl 1:
-        0'u64
-      else:
-        var i = leaf_index
-        while i >= bottom_length shl 1:
-          i = i shr 1
-        i
-
-  var
-    prefix_len = 0
-    proof_len = log2trunc(leaf_index)
-    cache = newSeq[Digest](bottom_length shl 1)
-  block:
-    var i = bottom_length
-    anchor.enumInstanceSerializedFields(fieldNameVar, fieldVar):
-      if i == parent_index:
-        when fieldVar is object:
-          prefix_len = log2trunc(leaf_index) - tree_depth
-          proof_len -= prefix_len
-          let
-            bottom_bits = leaf_index and not (uint64.high shl prefix_len)
-            prefix_leaf_index = (1'u64 shl prefix_len) + bottom_bits
-          build_proof_impl(fieldVar, prefix_leaf_index, proof)
-        else: raiseAssert "Invalid leaf_index"
-      cache[i] = hash_tree_root(fieldVar)
-      i += 1
-    for i in countdown(bottom_length - 1, 1):
-      cache[i] = computeDigest:
-        h.update cache[i shl 1].data
-        h.update cache[i shl 1 + 1].data
-
-  var i = if parent_index != 0: parent_index
-          else: leaf_index
-  doAssert i > 0 and i < bottom_length shl 1
-  for proof_index in prefix_len ..< prefix_len + proof_len:
-    let b = (i and 1) != 0
-    i = i shr 1
-    proof[proof_index] = if b: cache[i shl 1]
-                         else: cache[i shl 1 + 1]
-
-func build_proof*(anchor: object, leaf_index: uint64,
-                  proof: var openArray[Digest]) =
-  doAssert leaf_index > 0
-  doAssert proof.len == log2trunc(leaf_index)
-  build_proof_impl(anchor, leaf_index, proof)

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -21,6 +21,10 @@ const
   bytesPerChunk* = 32
 
 type
+  # TODO Figure out what would be the right type for this.
+  #      It probably fits in uint16 for all practical purposes.
+  GeneralizedIndex* = uint32
+
   UintN* = SomeUnsignedInt|UInt128|UInt256
   BasicType* = bool|UintN
 

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -11,4 +11,5 @@ import
   ./test_ssz_roundtrip,
   ./test_ssz_serialization,
   ./test_ssz_union,
-  ./test_merkleization
+  ./test_merkleization,
+  ./test_merkleization_types

--- a/tests/test_merkleization_types.nim
+++ b/tests/test_merkleization_types.nim
@@ -1,0 +1,400 @@
+# ssz_serialization
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  std/[sequtils, tables],
+  unittest2,
+  stew/[endians2, results],
+  ../ssz_serialization/merkleization
+
+func d(x: openArray[byte]): Digest =
+  result.data[0 ..< x.len] = x
+
+func d(x: openArray[UintN]): Digest =
+  for i, v in x:
+    result.data[i * sizeof(v) ..< (i + 1) * sizeof(v)] = toBytesLE(v)
+
+func d(x: UintN): Digest =
+  d([x])
+
+func d(a, b: Digest): Digest =
+  computeDigest:
+    h.update a.data
+    h.update b.data
+
+type
+  E = object
+    x: bool
+    y: bool
+  X = object
+    a: bool
+    b: uint8
+    c: uint16
+    d: uint32
+    e: uint64
+    f: Uint128
+    g: Uint256
+    h: BitArray[40]
+    i: BitArray[333]
+    j: BitList[40]
+    k: BitList[333]
+    l: BitList[333]
+    m: BitList[333]
+    n: BitList[333]
+    o: array[2, bool]
+    p: array[6, uint64]
+    q: array[2, E]
+    r: List[E, 2]
+    s: List[E, 2]
+    t: SingleMemberUnion[E]
+    u: E
+    v: tuple[a, b: bool]
+    w: tuple[a, b: E, c: bool]
+    x: HashArray[2, E]
+    y: HashList[E, 2]
+    z: HashList[E, 2]
+let
+  x = X(
+    a: true,
+    b: 0x08'u8,
+    c: 0x1616'u16,
+    d: 0x32323232'u32,
+    e: 0x6464646464646464'u64,
+    f: 0x01281281281281281281281281281280.u128,
+    g: 0x02562562562562562562562562562562562562562560.u256,
+    h: BitArray[40](bytes: [
+      0b01010101'u8, 0b10101010'u8, 0b11111111'u8,
+      0b10101010'u8, 0b01010101'u8]),
+    i: BitArray[333](bytes: [
+      0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+      32, 33, 34, 35, 36, 37, 38, 39, 40, 0b11111]),
+    j: BitList[40](@[
+      0b01010101'u8, 0b10101010'u8, 0b11111111'u8,
+      0b10101010'u8, 0b01010101'u8, 0b1'u8]),
+    k: BitList[333](@[
+      0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+      32, 33, 34, 35, 36, 37, 38, 39, 40, 0b111111]),
+    l: BitList[333](@[
+      0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 0xFF]),
+    m: BitList[333](@[
+      0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+      0x01]),
+    n: BitList[333](@[0x01'u8]),
+    o: [false, true],
+    p: [1'u64, 2, 3, 4, 5, 6],
+    q: [E(x: false, y: true), E(x: true, y: false)],
+    r: List[E, 2](@[E(x: false, y: true), E(x: true, y: false)]),
+    s: List[E, 2](@[]),
+    t: SingleMemberUnion[E](selector: 0, value: E(x: false, y: true)),
+    u: E(x: false, y: true),
+    v: (a: false, b: true),
+    w: (a: E(x: false, y: true), b: E(x: true, y: false), c: true),
+    x: HashArray[2, E](data: array[2, E](
+      [E(x: false, y: true), E(x: true, y: false)])),
+    y: HashList[E, 2].init(
+      @[E(x: false, y: true), E(x: true, y: false)]),
+    z: HashList[E, 2].init(@[]))
+  roots = block:
+    var res = {
+      # a
+      32: d(1'u8),
+
+      # b
+      33: d(0x08'u8),
+
+      # c
+      34: d(0x1616'u16),
+
+      # d
+      35: d(0x32323232'u32),
+
+      # e
+      36: d(0x6464646464646464'u64),
+
+      # f
+      37: d(0x01281281281281281281281281281280.u128),
+
+      # g
+      38: d(0x02562562562562562562562562562562562562562560.u256),
+
+      # h
+      39: d(0b01010101_10101010_11111111_10101010_01010101'u64),
+
+      # i
+      80: d([0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]),
+      81: d([32'u8, 33, 34, 35, 36, 37, 38, 39, 40, 0b11111]),
+
+      # j
+      82: d(0b01010101_10101010_11111111_10101010_01010101'u64),
+      83: d(40'u64),
+
+      # k
+      168: d([0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]),
+      169: d([32'u8, 33, 34, 35, 36, 37, 38, 39, 40, 0b11111]),
+      85: d(333'u64),
+
+      # l
+      172: d([0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 0x7F]),
+      173: d(0.u256),
+      87: d(255'u64),
+
+      # m
+      176: d([0'u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]),
+      177: d(0.u256),
+      89: d(256'u64),
+
+      # n
+      180: d(0.u256),
+      181: d(0.u256),
+      91: d(0'u64),
+
+      # o
+      46: d([0'u8, 1]),
+
+      # p
+      94: d([1'u64, 2, 3, 4]),
+      95: d([5'u64, 6]),
+
+      # q
+      192: d(0'u8),
+      193: d(1'u8),
+      194: d(1'u8),
+      195: d(0'u8),
+
+      # r
+      392: d(0'u8),
+      393: d(1'u8),
+      394: d(1'u8),
+      395: d(0'u8),
+      99: d(2'u64),
+
+      # s
+      200: d(0.u256),
+      201: d(0.u256),
+      101: d(0'u64),
+
+      # t
+      204: d(0'u8),
+      205: d(1'u8),
+      103: d(0'u8),
+
+      # u
+      104: d(0'u8),
+      105: d(1'u8),
+
+      # v
+      106: d(0'u8),
+      107: d(1'u8),
+
+      # w
+      432: d(0'u8),
+      433: d(1'u8),
+      434: d(1'u8),
+      435: d(0'u8),
+      218: d(1'u8),
+      219: d(0.u256),
+
+      # x
+      220: d(0'u8),
+      221: d(1'u8),
+      222: d(1'u8),
+      223: d(0'u8),
+
+      # y
+      448: d(0'u8),
+      449: d(1'u8),
+      450: d(1'u8),
+      451: d(0'u8),
+      113: d(2'u64),
+
+      # z
+      228: d(0.u256),
+      229: d(0.u256),
+      115: d(0'u64)
+    }.toOrderedTable
+    for i in 58 ..< 64:
+      res[i] = d(0.u256)
+    for i in [
+        40, 41, 84, 42, 86, 43, 88, 44, 90, 45, 47, 96, 97, 48,
+        196, 197, 98, 49, 100, 50, 102, 51, 52, 53, 216, 217, 108, 109, 54,
+        110, 111, 55, 224, 225, 112, 56, 114, 57]:
+      res[i] = d(res.getOrDefault(2 * i + 0), res.getOrDefault(2 * i + 1))
+    for i in countdown(31, 1):
+      res[i] = d(res.getOrDefault(2 * i + 0), res.getOrDefault(2 * i + 1))
+    res
+
+suite "Merkleization types":
+  test "All generalized indices with content":
+    for i, r in roots:
+      checkpoint $i
+      var root {.noinit.}: array[1, Digest]
+      hash_tree_root(x, [i.GeneralizedIndex], root).get
+      check:
+        root == [r]
+        hash_tree_root(x, [i.GeneralizedIndex]).get == [r]
+        hash_tree_root(x, i.GeneralizedIndex).get == r
+
+  test "All members of root object":
+    var i = 32
+    enumInstanceSerializedFields(x, _ {.used.}, field):
+      checkpoint $i
+      let r = roots.getOrDefault(i)
+      var root {.noinit.}: array[1, Digest]
+      hash_tree_root(x, [i.GeneralizedIndex], root).get
+      check:
+        root == [r]
+        hash_tree_root(x, [i.GeneralizedIndex]).get == [r]
+        hash_tree_root(x, i.GeneralizedIndex).get == r
+        hash_tree_root(field) == r
+      inc i
+
+  test "Generalized index 1 (static)":
+    const i = 1
+    let r = roots.getOrDefault(i)
+    var root {.noinit.}: array[1, Digest]
+    hash_tree_root(x, [i.GeneralizedIndex], root).get
+    check:
+      root == [r]
+      hash_tree_root(x, [i.GeneralizedIndex]).get == [r]
+      hash_tree_root(x, i.GeneralizedIndex).get == r
+      hash_tree_root(x) == r
+
+  test "Generalized index 2 (static)":
+    const i = 2
+    let r = roots.getOrDefault(i)
+    var root {.noinit.}: array[1, Digest]
+    hash_tree_root(x, [i.GeneralizedIndex], root).get
+    check:
+      root == [r]
+      hash_tree_root(x, [i.GeneralizedIndex]).get == [r]
+      hash_tree_root(x, i.GeneralizedIndex).get == r
+
+  test "Unknown generalized indices (errors)":
+    for i in 0 ..< 1024:
+      if roots.hasKey(i): continue
+      checkpoint $i
+      var root {.noinit.}: array[1, Digest]
+      check:
+        hash_tree_root(x, [i.GeneralizedIndex], root).isErr
+        hash_tree_root(x, [i.GeneralizedIndex]).isErr
+        hash_tree_root(x, i.GeneralizedIndex).isErr
+
+  test "Generalized index 999 (error - static)":
+    const i = 999
+    var root {.noinit.}: array[1, Digest]
+    check:
+      hash_tree_root(x, [i.GeneralizedIndex], root).isErr
+      hash_tree_root(x, [i.GeneralizedIndex]).isErr
+      hash_tree_root(x, i.GeneralizedIndex).isErr
+
+  test "Generalized index 0 (error)":
+    let i = 0
+    var root {.noinit.}: array[1, Digest]
+    check:
+      hash_tree_root(x, [i.GeneralizedIndex], root).isErr
+      hash_tree_root(x, [i.GeneralizedIndex]).isErr
+      hash_tree_root(x, i.GeneralizedIndex).isErr
+
+  test "Generalized index 0 (error - static)":
+    const i = 0
+    var root {.noinit.}: array[1, Digest]
+    check:
+      hash_tree_root(x, [i.GeneralizedIndex], root).isErr
+      hash_tree_root(x, [i.GeneralizedIndex]).isErr
+      hash_tree_root(x, i.GeneralizedIndex).isErr
+
+  test "Generalized index max (error)":
+    let i = GeneralizedIndex.high
+    var root {.noinit.}: array[1, Digest]
+    check:
+      hash_tree_root(x, [i], root).isErr
+      hash_tree_root(x, [i]).isErr
+      hash_tree_root(x, i).isErr
+
+  test "Generalized index max (error - static)":
+    const i = GeneralizedIndex.high
+    var root {.noinit.}: array[1, Digest]
+    check:
+      hash_tree_root(x, [i], root).isErr
+      hash_tree_root(x, [i]).isErr
+      hash_tree_root(x, i).isErr
+
+  test "Multiproof":
+    let
+      i = [32.GeneralizedIndex, 85, 80, 46, 103, 395, 219, 218, 435, 100]
+      r = i.mapIt(roots.getOrDefault(it.int))
+    var roots {.noinit.}: array[i.len, Digest]
+    hash_tree_root(x, i, roots).get
+    check:
+      roots == r
+      hash_tree_root(x, i).get == roots
+
+  test "Multiproof (static)":
+    const i = [32.GeneralizedIndex, 85, 80, 46, 103, 395, 219, 218, 435, 100]
+    let r = i.mapIt(roots.getOrDefault(it.int))
+    var roots {.noinit.}: array[i.len, Digest]
+    hash_tree_root(x, i, roots).get
+    check:
+      roots == r
+      hash_tree_root(x, i).get == roots
+
+  test "Multiproof (empty)":
+    let
+      i: array[0, GeneralizedIndex] = []
+      r: array[0, Digest] = []
+    var roots {.noinit.}: array[i.len, Digest]
+    hash_tree_root(x, i, roots).get
+    check:
+      roots == r
+      hash_tree_root(x, i).get == roots
+
+  test "Multiproof (empty - static)":
+    const i: array[0, GeneralizedIndex] = []
+    let r: array[0, Digest] = []
+    var roots {.noinit.}: array[i.len, Digest]
+    hash_tree_root(x, i, roots).get
+    check:
+      roots == r
+      hash_tree_root(x, i).get == roots
+
+  test "Multiproof (error)":
+    let i = [32.GeneralizedIndex, 85, 80, 46, 103, 395, 219, 218, 435, 999]
+    var roots {.noinit.}: array[i.len, Digest]
+    check:
+      hash_tree_root(x, i, roots).isErr
+      hash_tree_root(x, i).isErr
+
+  test "Multiproof (error - static)":
+    const i = [32.GeneralizedIndex, 85, 80, 46, 103, 395, 219, 218, 435, 999]
+    var roots {.noinit.}: array[i.len, Digest]
+    check:
+      hash_tree_root(x, i, roots).isErr
+      hash_tree_root(x, i).isErr
+
+  test "Multiproof (invalid indices)":
+    let i = [1.GeneralizedIndex, 2, 3]
+    var roots {.noinit.}: array[i.len, Digest]
+    check:
+      hash_tree_root(x, i, roots).isErr
+      hash_tree_root(x, i).isErr
+
+  test "Multiproof (invalid indices - static)":
+    const i = [1.GeneralizedIndex, 2, 3]
+    var roots {.noinit.}: array[i.len, Digest]
+    check:
+      hash_tree_root(x, i, roots).isErr
+      hash_tree_root(x, i).isErr

--- a/tests/test_proofs.nim
+++ b/tests/test_proofs.nim
@@ -52,9 +52,13 @@ suite "Merkle proofs":
         ]
 
   test "verify_merkle_multiproof":
+    var allLeaves: array[8, Digest]
+    for i in 0 ..< allLeaves.len:
+      allLeaves[i] = digest([i.byte])
+
     var nodes: array[16, Digest]
-    for i in countdown(15, 8):
-      nodes[i] = digest([i.byte])
+    for i in 0 ..< allLeaves.len:
+      nodes[i + 8] = allLeaves[i]
     for i in countdown(7, 1):
       nodes[i] = computeDigest:
         h.update nodes[2 * i + 0].data
@@ -69,6 +73,7 @@ suite "Merkle proofs":
         root = nodes[1]
       checkpoint "Verifying " & $indices & "---" & $helper_indices
       check:
+        proof == build_proof(allLeaves, indices).get
         verify_merkle_multiproof(leaves, proof, indices, root)
 
     verify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])


### PR DESCRIPTION
This adds functionality for building merkle multiproofs in the same form
that the Ethereum consensus specs suggest, i.e., in descending order of
helper indices. Merkle multiproofs are useful for the light client sync.
https://github.com/ethereum/consensus-specs/blob/v1.1.6/ssz/merkle-proofs.md#merkle-multiproofs