### PR TITLE
Set raises to specific error in reallyRaiseMalformedSszError

### DIFF
--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -20,7 +20,7 @@ export
   types
 
 func reallyRaiseMalformedSszError(typeName, msg: string) {.
-    raisesssz, noinline, noreturn.} =
+    raises: [Defect, MalformedSszError], noinline, noreturn.} =
   # `noinline` helps keep the C code tight on the happy path
   # passing `typeName` in avoids generating generic copies of this function
   raise (ref MalformedSszError)(msg: "SSZ " & typeName & ": " & msg)


### PR DESCRIPTION
Only raising the proper error, which is the same effect it gave with the template like it was before https://github.com/status-im/nim-ssz-serialization/pull/24

Honestly, I find the whole use of the `raisesssz` pragma rather counter productive. It "hides" a bit the actual errors from the user (and user would not have access to this pragma). And it also allows for laziness, in the sense that one just repeats the `raisesssz` instead of the actual errors, which seems to happen. At which point one could question why there are even these different errors and not just one `SszError`. `SszSizeMismatchError` is also not used much at all, and not even for `raiseIncorrectSize()`.

