### PR TITLE
rename mutable `[]` to `mitem`

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -352,6 +352,18 @@ template len*(x: HashList|HashArray): auto = len(x.data)
 template low*(x: HashList|HashArray): auto = low(x.data)
 template high*(x: HashList|HashArray): auto = high(x.data)
 template `[]`*(x: HashList|HashArray, idx: auto): auto = x.data[idx]
+template `[]`*(x: var HashList, idx: auto): auto =
+  {.fatal: "Use item / mitem with `var HashXxx` to differentiate read/write access".}
+  discard
+template `[]`*(x: var HashArray, idx: auto): auto =
+  {.fatal: "Use item / mitem with `var HashXxx` to differentiate read/write access".}
+  discard
+
+template item*(x: HashList|HashArray, idx: auto): auto =
+  # We must use a template, or the magic `unsafeAddr x[idx]` won't work, but
+  # we don't want to accidentally return a `var` instance that gets mutated
+  # so we avoid overloading the `[]` name
+  x.data[idx]
 
 func mitem*(a: var HashArray, b: auto): var a.T =
   # Access mutable item clearing its cache

--- a/tests/test_ssz_serialization.nim
+++ b/tests/test_ssz_serialization.nim
@@ -149,6 +149,12 @@ suite "SSZ navigator":
       leaves3.add c
       hash_tree_root(leaves3) == hash_tree_root(leaves3.data)
 
+    # cache invalidation on modification
+    leaves3.mitem(0) = b
+    check:
+      leaves3.data[0] == b
+      hash_tree_root(leaves3) == hash_tree_root(leaves3.data)
+
   test "basictype":
     var leaves = HashList[uint64, 1'i64 shl 3]()
     while leaves.len < leaves.maxLen:

--- a/tests/test_ssz_serialization.nim
+++ b/tests/test_ssz_serialization.nim
@@ -199,6 +199,7 @@ suite "hash":
       o = Obj()
       ho = HashObj()
 
+    template mitem(v: array, idx: auto): auto = v[idx]
     template both(body) =
       block:
         template it: auto {.inject.} = o
@@ -215,7 +216,7 @@ suite "hash":
         o.li == ho.li.data
         htro == htrho
 
-    both: it.arr[0].data[0] = byte 1
+    both: it.arr.mitem(0).data[0] = byte 1
 
     both: check: it.li.add Digest()
 


### PR DESCRIPTION
Having `[]` invalidate the cache is convenient, but comes at a
(significant) performance cost as it gets called even for non-mutable
access due to mutability leaks in the language

*`mitem` like `mitems`