### PR TITLE
fix 'noInit' should be: 'noinit'

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -906,7 +906,7 @@ func hashTreeRootAux[T](
       firstChunkIndex = nextPow2(totalChunks.uint64)
       chunkLayer = log2trunc(firstChunkIndex)
     var
-      combinedChunks {.noInit.}: array[chunkLayer + 1, Digest]
+      combinedChunks {.noinit.}: array[chunkLayer + 1, Digest]
       i = slice.a
       fieldIndex = 0.Limit
       isActive = false


### PR DESCRIPTION
Correct capitalization of a `noinit` keyword to pass stylecheck.