### PR TITLE
update for latest `Optional` spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,12 @@ jobs:
           nim --version
           nimble --version
           nimble install -y --depsOnly
-          env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
-          env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
-          if [[ "${{ matrix.branch }}" == "devel" ]]; then
+          if [[ "${{ matrix.branch }}" == "version-1-6" ]]; then
+            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
+            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
+          else
+            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
+            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
             echo -e "\nTesting with Nim devel default (currently '--mm:orc'):\n"
             if [[ "${{ matrix.target.cpu }}" == "i386" ]]; then
               env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,11 +185,8 @@ jobs:
                 echo "Nim devel with --mm:orc no longer times out! Please remove this check in ci.yml"
                 false
               fi
-              if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" gtimeout 60m nimble test; then
+              if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test; then
                 echo "Nim devel with --mm:orc works again! Please remove this check in ci.yml"
-                false
-              elif (( $? != 124 )); then
-                echo "Nim devel with --mm:orc no longer times out! Please remove this check in ci.yml"
                 false
               fi
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,17 @@ jobs:
           if [[ "${{ matrix.branch }}" == "version-1-6" ]]; then
             env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
             env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
+          elif [[ "${{ matrix.branch }}" != "devel" ]]; then
+            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
+            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
+            if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test; then
+              echo "Nim ${{ matrix.branch }} with --mm:orc (C) works again! Please remove this check in ci.yml"
+              false
+            fi
+            if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test; then
+              echo "Nim ${{ matrix.branch }} with --mm:orc (CPP) works again! Please remove this check in ci.yml"
+              false
+            fi
           else
             env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
             env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           else
             env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
             env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
-            echo -e "\nTesting with Nim devel default (currently '--mm:orc'):\n"
+            echo -e "\nTesting with Nim ${{ matrix.branch }} `--mm` default (currently '--mm:orc'):\n"
             if [[ "${{ matrix.target.cpu }}" == "i386" ]]; then
               env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
               env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
@@ -182,23 +182,23 @@ jobs:
               # https://github.com/status-im/nim-ssz-serialization/actions/runs/4807288565/jobs/8563823711?pr=45
               brew install coreutils
               if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" gtimeout 60m nimble test; then
-                echo "Nim devel with --mm:orc works again! Please remove this check in ci.yml"
+                echo "Nim ${{ matrix.branch }} with --mm:orc (C) works again! Please remove this check in ci.yml"
                 false
               elif (( $? != 124 )); then
-                echo "Nim devel with --mm:orc no longer times out! Please remove this check in ci.yml"
+                echo "Nim ${{ matrix.branch }} with --mm:orc (C) no longer times out! Please remove this check in ci.yml"
                 false
               fi
               if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test; then
-                echo "Nim devel with --mm:orc works again! Please remove this check in ci.yml"
+                echo "Nim ${{ matrix.branch }} with --mm:orc (CPP) works again! Please remove this check in ci.yml"
                 false
               fi
             else
               if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test; then
-                echo "Nim devel with --mm:orc works again! Please remove this check in ci.yml"
+                echo "Nim ${{ matrix.branch }} with --mm:orc (C) works again! Please remove this check in ci.yml"
                 false
               fi
               if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test; then
-                echo "Nim devel with --mm:orc works again! Please remove this check in ci.yml"
+                echo "Nim ${{ matrix.branch }} with --mm:orc (CPP) works again! Please remove this check in ci.yml"
                 false
               fi
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,8 @@ jobs:
             env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
             env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
           else
-            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
-            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
+            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
+            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
             echo -e "\nTesting with Nim devel default (currently '--mm:orc'):\n"
             if [[ "${{ matrix.target.cpu }}" == "i386" ]]; then
               env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,12 +166,17 @@ jobs:
           env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
           if [[ "${{ matrix.branch }}" == "devel" ]]; then
             echo -e "\nTesting with '--gc:orc':\n"
-            if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test; then
-              echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"
-              false
-            fi
-            if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test; then
-              echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"
-              false
+            if [[ "${{ matrix.target.cpu == 'i386' }}" ]]; then
+              env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
+              env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
+            else
+              if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test; then
+                echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"
+                false
+              fi
+              if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test; then
+                echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"
+                false
+              fi
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
           if [[ "${{ matrix.branch }}" == "devel" ]]; then
             echo -e "\nTesting with '--gc:orc':\n"
-            if [[ "${{ matrix.target.cpu == 'i386' }}" ]]; then
+            if [[ "${{ matrix.target.cpu }}" == "i386" ]]; then
               env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
               env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,22 @@ jobs:
             if [[ "${{ matrix.target.cpu }}" == "i386" ]]; then
               env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
               env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
+            elif [[ "${{ matrix.target.os }}" == "macos" ]]; then
+              brew install coreutils
+              if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" gtimeout 30m nimble test; then
+                echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"
+                false
+              elif (( $? != 124 )); then
+                echo "Nim devel with --gc:orc no longer times out! Please remove this check in ci.yml"
+                false
+              fi
+              if env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --gc:orc" gtimeout 30m nimble test; then
+                echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"
+                false
+              elif (( $? != 124 )); then
+                echo "Nim devel with --gc:orc no longer times out! Please remove this check in ci.yml"
+                false
+              fi
             else
               if env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test; then
                 echo "Nim devel with --gc:orc works again! Please remove this check in ci.yml"

--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -167,6 +167,7 @@ proc writeVarSizeType(w: var SszWriter, value: auto) {.raises: [Defect, IOError]
     writeSeq(w, bytes value)
   elif value is OptionalType:
     if value.isSome:
+      w.writeValue 1'u8
       w.writeValue value.get
   elif value is object|tuple|array:
     when isCaseObject(type(value)):
@@ -243,7 +244,7 @@ func sszSize*(value: auto): int {.gcsafe, raises:[].} =
 
   elif T is OptionalType:
     if value.isSome:
-      sszSize(value.unsafeGet)
+      1 + sszSize(value.unsafeGet)
     else:
       0
 

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -341,8 +341,13 @@ proc readSszValue*[T](input: openArray[byte],
       else:
         val = Opt.none(E)
     else:
+      var isSome: uint8
+      readSszValue(input.toOpenArray(0, 0), isSome)
+      if isSome != 1:
+        raiseMalformedSszError(
+          T, "Unexpected isSome " & $isSome & " (expected: 1)")
       var v: E
-      readSszValue(input, v)
+      readSszValue(input.toOpenArray(1, input.len - 1), v)
       when val is Option:
         val = options.some(v)
       else:

--- a/tests/test_ssz_optional.nim
+++ b/tests/test_ssz_optional.nim
@@ -17,10 +17,10 @@ import
 proc doTest[T](name: string, value: Option[T] | Opt[T]) =
   test name:
     const isUnsupported =
-      when T is object:
-        when T is OptionalType:
-          false
-        elif T.isCaseObject():
+      when T is OptionalType:
+        false
+      elif T is object:
+        when T.isCaseObject():
           true
         else:
           false


### PR DESCRIPTION
EIP-6475 was bumped to emit an additional `0x01` byte in the `Some` case of optionals to allow nesting `Optional` and `Optional[List]` and to provide compatibility with `Union` serialization. Note that the `None` case is still serialized as empty.

https://eips.ethereum.org/EIPS/eip-6475
https://github.com/ethereum/EIPs/pull/6945