### PR TITLE
rm unused `SszMaxSizeExceeded`

### DIFF
--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -1,5 +1,5 @@
 # ssz_serialization
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -32,7 +32,6 @@ type
     stream: OutputStream
 
   SizePrefixed*[T] = distinct T
-  SszMaxSizeExceeded* = object of SerializationError
 
   VarSizedWriterCtx = object
     fixedParts: WriteCursor


### PR DESCRIPTION
The type `SszMaxSizeExceeded` is unused and can be removed.