### PR TITLE
bulk-copy simple types

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -158,25 +158,25 @@ template asSeq*(x: List): auto = distinctBase(x)
 template init*[T, N](L: type List[T, N], x: seq[T]): auto =
   List[T, N](x)
 
-template `$`*(x: List): auto = $(distinctBase x)
-template len*(x: List): auto = len(distinctBase x)
-template low*(x: List): auto = low(distinctBase x)
-template high*(x: List): auto = high(distinctBase x)
+template `$`*(x: List): auto = $(distinctBase(x))
+template len*(x: List): auto = len(distinctBase(x))
+template low*(x: List): auto = low(distinctBase(x))
+template high*(x: List): auto = high(distinctBase(x))
 template `[]`*(x: List, idx: auto): untyped = distinctBase(x)[idx]
 template `[]=`*(x: var List, idx: auto, val: auto) = distinctBase(x)[idx] = val
 template `==`*(a, b: List): bool = distinctBase(a) == distinctBase(b)
 
 template `&`*(a, b: List): auto = (type(a)(distinctBase(a) & distinctBase(b)))
 
-template items* (x: List): untyped = items(distinctBase x)
-template pairs* (x: List): untyped = pairs(distinctBase x)
-template mitems*(x: var List): untyped = mitems(distinctBase x)
-template mpairs*(x: var List): untyped = mpairs(distinctBase x)
-template contains* (x: List, val: auto): untyped = contains(distinctBase x, val)
+template items* (x: List): untyped = items(distinctBase(x))
+template pairs* (x: List): untyped = pairs(distinctBase(x))
+template mitems*(x: var List): untyped = mitems(distinctBase(x))
+template mpairs*(x: var List): untyped = mpairs(distinctBase(x))
+template contains* (x: List, val: auto): untyped = contains(distinctBase(x), val)
 
 func add*(x: var List, val: auto): bool =
   if x.len < x.maxLen:
-    add(distinctBase x, val)
+    add(distinctBase(x), val)
     true
   else:
     false
@@ -186,16 +186,16 @@ func setLenUninitialized*(x: var List, newLen: int): bool =
     # TODO https://github.com/nim-lang/Nim/issues/19727
     when List.T is SomeNumber:
       if x.len !=  newLen:
-        distinctBase x = newSeqUninitialized[x.T](newLen)
+        distinctBase(x) = newSeqUninitialized[x.T](newLen)
     else:
-      setLen(distinctBase x, newLen)
+      setLen(distinctBase(x), newLen)
     true
   else:
     false
 
 func setLen*(x: var List, newLen: int): bool =
   if newLen <= x.maxLen:
-    setLen(distinctBase x, newLen)
+    setLen(distinctBase(x), newLen)
     true
   else:
     false

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -146,11 +146,12 @@ type
     actualSszSize*: int
     elementSize*: int
 
-  # These are supported by the SSZ library - anything that's not covered here
-  # needs to overload toSszType and fromSszBytes
+  # These are directly supported by the SSZ library - anything that's not
+  # covered here needs to create overloads for toSszType / fromSszBytes
+  # (basic types) or writeValue / readValue (complex types)
   SszType* =
     BasicType | array | HashArray | List | HashList | BitArray | BitList |
-    object | tuple
+    Digest | object | tuple
 
 template asSeq*(x: List): auto = distinctBase(x)
 
@@ -176,6 +177,18 @@ template contains* (x: List, val: auto): untyped = contains(distinctBase x, val)
 func add*(x: var List, val: auto): bool =
   if x.len < x.maxLen:
     add(distinctBase x, val)
+    true
+  else:
+    false
+
+func setLenUninitialized*(x: var List, newLen: int): bool =
+  if newLen <= x.maxLen:
+    # TODO https://github.com/nim-lang/Nim/issues/19727
+    when List.T is SomeNumber:
+      if x.len !=  newLen:
+        distinctBase x = newSeqUninitialized[x.T](newLen)
+    else:
+      setLen(distinctBase x, newLen)
     true
   else:
     false
@@ -443,6 +456,21 @@ template ElemType*(T: type seq): untyped =
 template ElemType*(T0: type List): untyped =
   T0.T
 
+func supportsBulkCopy*(T: type): bool {.compileTime.} =
+  # Bulk copy types are those that match the following requirements:
+  # * have no padding / alignment differences compared to their raw SSZ encoding
+  # * have no validity constraints (ie bool which must be 0/1)
+  # * supportsCopyMem (of course)
+  when T is array:
+    supportsBulkCopy(ElemType(T))
+  elif T is Digest:
+    true
+  else:
+    when cpuEndian == bigEndian:
+      T is byte
+    else:
+      T is UintN
+
 func isFixedSize*(T0: type): bool {.compileTime.} =
   mixin toSszType, enumAllSerializedFields
 
@@ -569,10 +597,7 @@ func getFieldBoundingOffsets*(RecordType: type,
   anonConst getFieldBoundingOffsetsImpl(T, fieldName)
 
 template enumerateSubFields*(holder, fieldVar, body: untyped) =
-  when holder is array|HashArray:
-    for fieldVar in holder: body
-  else:
-    enumInstanceSerializedFields(holder, _{.used.}, fieldVar): body
+  enumInstanceSerializedFields(holder, _{.used.}, fieldVar): body
 
 method formatMsg*(
   err: ref SszSizeMismatchError,


### PR DESCRIPTION
When loading SSZ from disk, we can bulk-memcpy trivial types that match the SSZ serialization exactly (ie `array[Digest]`) - this saves a few ms when loading large SSZ objects like beacon states.

Also avoid zero:ing seqs on load - unfortunately, this works only for numbers).