### PR TITLE
remove SingleMemberUnion read/write support

### DIFF
--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -44,7 +44,7 @@ template sizePrefixed*[TT](x: TT): untyped =
   type T = TT
   SizePrefixed[T](x)
 
-proc init*(T: type SszReader,
+func init*(T: type SszReader,
            stream: InputStream): T =
   T(stream: stream)
 
@@ -89,7 +89,7 @@ func init*(T: type SszWriter, stream: OutputStream): T =
 
 proc writeVarSizeType(w: var SszWriter, value: auto) {.gcsafe, raises: [IOError].}
 
-proc beginRecord*(w: var SszWriter, TT: type): auto  =
+func beginRecord*(w: var SszWriter, TT: type): auto  =
   type T = TT
   when isFixedSize(T):
     FixedSizedWriterCtx()
@@ -156,10 +156,6 @@ proc writeVarSizeType(w: var SszWriter, value: auto) {.raises: [IOError].} =
 
   when value is HashArray|HashList:
     writeVarSizeType(w, value.data)
-  elif value is SingleMemberUnion:
-    doAssert value.selector == 0'u8
-    w.writeValue 0'u8
-    w.writeValue value.value
   elif value is array:
     writeElements(w, value)
   elif value is List:
@@ -241,9 +237,6 @@ func sszSize*(value: auto): int {.gcsafe, raises:[].} =
 
   elif T is BitList:
     return len(bytes(value))
-
-  elif T is SingleMemberUnion:
-    sszSize(toSszType value.value) + 1
 
   elif T is OptionalType:
     if value.isSome:

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -36,7 +36,7 @@ template setOutputSize[R, T](a: var array[R, T], length: int) =
   if length != a.len:
     raiseIncorrectSize a.type
 
-proc setOutputSize(list: var List, length: int) {.raisesssz.} =
+func setOutputSize(list: var List, length: int) {.raisesssz.} =
   # We will overwrite all bytes
   if not list.setLenUninitialized length:
     raiseMalformedSszError(typeof(list), "length exceeds list limit")
@@ -65,7 +65,7 @@ func fromSszBytes*(T: type Digest, data: openArray[byte]): T {.raisesssz, noinit
 template fromSszBytes*(T: type BitSeq, bytes: openArray[byte]): auto =
   BitSeq @bytes
 
-proc `[]`[T, U, V](s: openArray[T], x: HSlice[U, V]) {.error:
+func `[]`[T, U, V](s: openArray[T], x: HSlice[U, V]) {.error:
   "Please don't use openArray's [] as it allocates a result sequence".}
 
 template checkForForbiddenBits(ResulType: type,
@@ -351,12 +351,6 @@ proc readSszValue*[T](input: openArray[byte],
         val = options.some(v)
       else:
         val = Opt.some(v)
-
-  elif val is SingleMemberUnion:
-    readSszValue(input.toOpenArray(0, 0), val.selector)
-    if val.selector != 0'u8:
-      raiseMalformedSszError(T, "SingleMemberUnion selector must be 0")
-    readSszValue(input.toOpenArray(1, input.len - 1), val.value)
 
   elif val is UintN|bool:
     val = fromSszBytes(T, input)


### PR DESCRIPTION
The `SingleMemberUnion` is a never-used vestige of https://github.com/status-im/nimbus-eth2/pull/2858 which tentatively [defined a `Transaction` as an SSZ `Union`](https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/merge/beacon-chain.md#custom-types) briefly.

The 1.1.4 spec [switches it to the `ByteList`](https://github.com/ethereum/consensus-specs/blob/v1.1.4/specs/merge/beacon-chain.md#custom-types) it remains.

The idea of something like a `SingleMemberUnion` didn't entirely fade, but a more current representation is [implemented already](https://github.com/status-im/nim-ssz-serialization/pull/41), so at this point `SingleMemberUnion` itself should be removed.