### PR TITLE
remove spurious `{.raises.}`

### DIFF
--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -265,7 +265,8 @@ func sszSize*(value: auto): int {.gcsafe, raises:[].} =
   else:
     unsupported T
 
-proc writeValue*[T](w: var SszWriter, x: SizePrefixed[T]) {.raises: [IOError].} =
+proc writeValue*[T](
+    w: var SszWriter, x: SizePrefixed[T]) {.raises: [IOError].} =
   var cursor = w.stream.delayVarSizeWrite(Leb128.maxLen(uint64))
   let initPos = w.stream.pos
   w.writeValue T(x)

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -623,8 +623,8 @@ template writeValue*(writer: var JsonWriter, value: List) =
   else:
     writeValue(writer, asSeq value)
 
-proc writeValue*(writer: var JsonWriter, value: HashList)
-                {.raises: [IOError, SerializationError].} =
+proc writeValue*(
+    writer: var JsonWriter, value: HashList) {.raises: [IOError].} =
   writeValue(writer, value.data)
 
 proc readValue*(reader: var JsonReader, value: var HashList)


### PR DESCRIPTION
Remove unnecessary `{.raises: [SerializationError].}` from `writeValue`. `SerializationError` can only occur while reading.