### PR TITLE
Fix hash_tree_root cannot compile with nim 1.6.12

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -195,6 +195,10 @@ template addChunkDirect(merkleizer: var SszMerkleizerImpl, body: untyped) =
   # add chunk allowing `body` to write directly to `chunk` memory thus avoiding
   # an extra copy - body must completely fill the chunk, including any zero
   # padding
+
+  # the following mixin is a workaround for nim 1.6.12
+  # and the bug seems to be fixed in nim 1.6.14
+  mixin combineChunks
   if getBitLE(merkleizer.totalChunks, 0):
     template chunk: Digest {.inject.} = merkleizer.combinedChunks[0][1]
     body

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -13,4 +13,5 @@ import
   ./test_ssz_serialization,
   ./test_ssz_union,
   ./test_merkleization,
-  ./test_merkleization_types
+  ./test_merkleization_types,
+  ./test_hash_tree_root

--- a/tests/test_hash_tree_root.nim
+++ b/tests/test_hash_tree_root.nim
@@ -1,0 +1,47 @@
+import
+  unittest2,
+  stew/byteutils,
+  ../ssz_serialization/merkleization
+
+type
+  Eth2Digest = object
+    data: array[32, byte]
+
+  ExecutionAddress = object
+    data: array[20, byte]
+
+  BloomLogs = object
+    data: array[256, byte]
+
+  UInt256 = object
+    data: array[32, byte]
+
+  ExecutionPayload* = object
+    # Execution block header fields
+    parent_hash*: Eth2Digest
+    fee_recipient*: ExecutionAddress
+      ## 'beneficiary' in the yellow paper
+    state_root*: Eth2Digest
+    receipts_root*: Eth2Digest
+    logs_bloom*: BloomLogs
+    prev_randao*: Eth2Digest
+      ## 'difficulty' in the yellow paper
+    block_number*: uint64
+      ## 'number' in the yellow paper
+    gas_limit*: uint64
+    gas_used*: uint64
+    timestamp*: uint64
+    extra_data*: List[byte, 32]
+    base_fee_per_gas*: UInt256
+
+    # Extra payload fields
+    block_hash*: Eth2Digest
+      ## Hash of execution block
+
+proc main() =
+  var h: ExecutionPayload
+  # under nim 1.6.12, hash_tree_root failed to compile
+  # but the bug fixed in nim > 1.6.14
+  let z = hash_tree_root(h)
+
+main()


### PR DESCRIPTION
fix #64
only need to add one mixin.