### PR TITLE
Don't reset HashList hash cache during in-place SSZ reading

### DIFF
--- a/ssz_serialization.nimble
+++ b/ssz_serialization.nimble
@@ -21,8 +21,7 @@ proc test(args, path: string) =
     mkDir "build"
   exec "nim " & getEnv("TEST_LANG", "c") & " " & getEnv("NIMFLAGS") & " " & args &
     " -r --skipParentCfg" &
-    " --styleCheck:usages --styleCheck:error" &
-    " --hint[XDeclaredButNotUsed]:off --hint[Processing]:off " &
+    " --styleCheck:usages --styleCheck:error --hint[Processing]:off " &
     path
 
 task test, "Run all tests":

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -293,7 +293,7 @@ proc readSszValue*[T](input: openArray[byte],
           raise ex
 
       val.data.setOutputSize input.len div elemSize
-      when supportsBulkCopy(type val.data[0]):
+      when supportsBulkCopy(type E):
         if val.data.len > 0:
           copyMem addr val.data[0], unsafeAddr input[0], input.len
 

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -237,20 +237,8 @@ macro initSszUnionImpl(RecordType: type, input: openArray[byte]): untyped =
 func initSszUnion(T: type, input: openArray[byte]): T {.raisesssz.} =
   initSszUnionImpl(T, input)
 
-type HashListOperations = ref object
-  clearCaches: proc(idx: int) {.noSideEffect, raises: [].}
-  resetCache: proc() {.noSideEffect, raises: [].}
-  resizeHashes: proc() {.noSideEffect, raises: [].}
-
-func hashListClosures(hl: ptr auto): HashListOperations =
-  HashListOperations(
-    clearCaches: func(idx: int) {.raises: [].} = clearCaches(hl[], idx),
-    resetCache: func() {.raises: [].} = resetCache(hl[]),
-    resizeHashes: func() {.raises: [].} = resizeHashes hl[])
-
 proc readSszValue*[T](input: openArray[byte],
-                      val: var T,
-                      hashListOperations: HashListOperations = nil) {.raisesssz.} =
+                      val: var T) {.raisesssz.} =
   mixin fromSszBytes, toSszType
 
   template readOffsetUnchecked(n: int): uint32 {.used.}=
@@ -292,7 +280,87 @@ proc readSszValue*[T](input: openArray[byte],
       checkForForbiddenBits(T, input, val.maxLen + 1)
 
   elif val is HashList:
-    readSszValue(input, val.data, hashListClosures(addr val))
+    type E = ElemType(type val)
+
+    when isFixedSize(E):
+      const elemSize = fixedPortionSize(E)
+      when elemSize > 1:
+        if input.len mod elemSize != 0:
+          var ex = new SszSizeMismatchError
+          ex.deserializedType = cstring typetraits.name(T)
+          ex.actualSszSize = input.len
+          ex.elementSize = elemSize
+          raise ex
+
+      val.data.setOutputSize input.len div elemSize
+      when supportsBulkCopy(type val.data[0]):
+        if val.data.len > 0:
+          copyMem addr val.data[0], unsafeAddr input[0], input.len
+
+        # There's no selective invalidation here, because it would require a
+        # potential performance tradeoff, either interfering with bulk copy,
+        # or involving more verification of changed hash entries.
+        val.resetCache()
+      else:
+        var prevValue: E
+        val.resizeHashes()
+
+        for i in 0 ..< val.len:
+          let offset = i * elemSize
+          assign(prevValue, val.data[i])
+          readSszValue(
+            input.toOpenArray(offset, offset + elemSize - 1), val.data[i])
+          if prevValue != val.data[i]:
+            val.clearCaches(i)
+
+        # Unconditionally trigger small, O(1) updates to handle when the list
+        # shrinks without otherwise changing.
+        val.clearCaches(0)
+        val.clearCaches(max(val.len - 1, 0))
+
+    else:
+      if input.len == 0:
+        # This is an empty list.
+        # The default initialization of the return value is fine.
+        val.data.setOutputSize 0
+        val.resetCache()
+        return
+      elif input.len < offsetSize:
+        raiseMalformedSszError(T, "input of insufficient size")
+
+      var offset = readOffset 0
+      let resultLen = offset div offsetSize
+
+      if resultLen == 0:
+        # If there are too many elements, other constraints detect problems
+        # (not monotonically increasing, past end of input, or last element
+        # not matching up with its nextOffset properly)
+        raiseMalformedSszError(T, "incorrect encoding of zero length")
+
+      val.data.setOutputSize resultLen
+      val.resizeHashes()
+
+      var prevValue: E
+      for i in 1 ..< resultLen:
+        let nextOffset = readOffset(i * offsetSize)
+        if nextOffset < offset:
+          raiseMalformedSszError(T, "list element offsets are decreasing")
+        else:
+          assign(prevValue, val.data[i - 1])
+          readSszValue(
+            input.toOpenArray(offset, nextOffset - 1), val.data[i - 1])
+          if prevValue != val.data[i - 1]:
+            val.clearCaches(i - 1)
+        offset = nextOffset
+
+      readSszValue(
+        input.toOpenArray(offset, input.len - 1), val.data[resultLen - 1])
+
+      # Unconditionally trigger small, O(1) updates to handle when the list
+      # shrinks without otherwise changing.
+      val.clearCaches(0)
+      val.clearCaches(max(val.len - 1, 0))
+
   elif val is HashArray:
     readSszValue(input, val.data)
     val.resetCache()
@@ -300,11 +368,6 @@ proc readSszValue*[T](input: openArray[byte],
     readSszValue(input, val.data)
   elif val is List|array:
     type E = ElemType(type val)
-
-    # This is arbitrary, but keeps the initial implementation from affecting
-    # non-HashLists.
-    when val is array:
-      doAssert hashListOperations.isNil
 
     when isFixedSize(E):
       const elemSize = fixedPortionSize(E)
@@ -320,32 +383,10 @@ proc readSszValue*[T](input: openArray[byte],
       when supportsBulkCopy(type val[0]):
         if val.len > 0:
           copyMem addr val[0], unsafeAddr input[0], input.len
-
-        # There's no selective invalidation here, because it would require a
-        # potential performance tradeoff, either interfering with bulk copy,
-        # or involving more verification of changed hash entries.
-        if not hashListOperations.isNil:
-          hashListOperations.resetCache()
       else:
-        if hashListOperations.isNil:
-          for i in 0 ..< val.len:
-            let offset = i * elemSize
-            readSszValue(input.toOpenArray(offset, offset + elemSize - 1), val[i])
-        else:
-          var prevValue: E
-          hashListOperations.resizeHashes()
-
-          for i in 0 ..< val.len:
-            let offset = i * elemSize
-            assign(prevValue, val[i])
-            readSszValue(input.toOpenArray(offset, offset + elemSize - 1), val[i])
-            if prevValue != val[i]:
-              hashListOperations.clearCaches(i)
-
-          # Unconditionally trigger small, O(1) updates to handle when the list
-          # shrinks without otherwise changing.
-          hashListOperations.clearCaches(0)
-          hashListOperations.clearCaches(max(val.len - 1, 0))
+        for i in 0 ..< val.len:
+          let offset = i * elemSize
+          readSszValue(input.toOpenArray(offset, offset + elemSize - 1), val[i])
 
     else:
       if input.len == 0:
@@ -366,36 +407,15 @@ proc readSszValue*[T](input: openArray[byte],
         raiseMalformedSszError(T, "incorrect encoding of zero length")
 
       val.setOutputSize resultLen
-      if hashListOperations.isNil:
-        for i in 1 ..< resultLen:
-          let nextOffset = readOffset(i * offsetSize)
-          if nextOffset < offset:
-            raiseMalformedSszError(T, "list element offsets are decreasing")
-          else:
-            readSszValue(input.toOpenArray(offset, nextOffset - 1), val[i - 1])
-          offset = nextOffset
-      else:
-        var prevValue: E
-        hashListOperations.resizeHashes()
-
-        for i in 1 ..< resultLen:
-          let nextOffset = readOffset(i * offsetSize)
-          if nextOffset < offset:
-            raiseMalformedSszError(T, "list element offsets are decreasing")
-          else:
-            assign(prevValue, val[i - 1])
-            readSszValue(input.toOpenArray(offset, nextOffset - 1), val[i - 1])
-            if prevValue != val[i - 1]:
-              hashListOperations.clearCaches(i - 1)
-          offset = nextOffset
+      for i in 1 ..< resultLen:
+        let nextOffset = readOffset(i * offsetSize)
+        if nextOffset < offset:
+          raiseMalformedSszError(T, "list element offsets are decreasing")
+        else:
+          readSszValue(input.toOpenArray(offset, nextOffset - 1), val[i - 1])
+        offset = nextOffset
 
       readSszValue(input.toOpenArray(offset, input.len - 1), val[resultLen - 1])
-
-      if not hashListOperations.isNil:
-        # Unconditionally trigger small, O(1) updates to handle when the list
-        # shrinks without otherwise changing.
-        hashListOperations.clearCaches(0)
-        hashListOperations.clearCaches(max(resultLen - 1, 0))
 
   elif val is OptionalType:
     type E = ElemType(T)

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -314,8 +314,7 @@ func clearCaches*(a: var HashList, dataIdx: int64) =
       layerIdx = idxInLayer + a.indices[layer]
 
     if layerIdx < a.indices[layer + 1]:
-      if  a.hashes[layerIdx].data.toOpenArray(0, 7) ==
-            static(default(array[8, byte])) and
+      if  (not isCached(a.hashes[layerIdx])) and
           a.hashes[layerIdx] != uninitSentinel:
         return
 

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -15,6 +15,8 @@ import
   json_serialization,
   "."/[bitseqs]
 
+from std/sequtils import newSeqWith
+
 from nimcrypto/utils import fromHex  # needed to disambiguate properly
 
 export stint, bitseqs, json_serialization
@@ -114,7 +116,7 @@ type
     ## stored in the `hashes` list - instead, `indices` keeps track of where in
     ## the list each level starts. When the length of `data` changes, the
     ## `hashes` and `indices` structures must be updated accordingly using
-    ## `growHashes`.
+    ## `resizeHashes`.
     ##
     ## All mutating operators (those that take `var HashList`) will
     ## automatically invalidate the cache for the relevant chunks - the leaf and
@@ -279,6 +281,24 @@ func cacheNodes*(depth, leaves: int): int =
     res += nodesAtLayer(i, depth, leaves)
   res
 
+# Indicates that after growing, the hashes, while they'll be considered cached,
+# also do not allow inference that layers nearer the Merkle hash tree have also
+# been cleared and that the hash cache clearing must continue to the root.
+#
+# False positives are possible, but harmless: if a cleared entry coincidentally
+# matches this pattern, then it inefficiently recomputes some Merkle tree nodes
+# and still creates a correct result.
+const uninitSentinel = Digest(data: [
+  0, 0, 0, 0, 0, 0, 0, 0,
+  1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1])
+
+# Aside from these conditions, the specific value of the sentinel is arbitrary.
+static:
+  doAssert uninitSentinel != default(Digest)
+  doAssert uninitSentinel.data.toOpenArray(0, 7) == default(array[8, byte])
+
 func clearCaches*(a: var HashList, dataIdx: int64) =
   ## Clear each level of the Merkle tree up to the root affected by a data
   ## change at `dataIdx`.
@@ -292,7 +312,13 @@ func clearCaches*(a: var HashList, dataIdx: int64) =
     let
       idxInLayer = idx - (1'i64 shl layer)
       layerIdx = idxInLayer + a.indices[layer]
+
     if layerIdx < a.indices[layer + 1]:
+      if  a.hashes[layerIdx].data.toOpenArray(0, 7) ==
+            static(default(array[8, byte])) and
+          a.hashes[layerIdx] != uninitSentinel:
+        return
+
       # Only clear cache when we're actually storing it - ie it hasn't been
       # skipped by the "combined zero hash" optimization
       clearCache(a.hashes[layerIdx])
@@ -307,28 +333,32 @@ func clearCache*(a: var HashList) =
   # contents
   for c in a.hashes.mitems(): clearCache(c)
 
-func growHashes*(a: var HashList) =
-  ## Ensure that the hash cache is big enough for the data in the list - must
-  ## be called whenever `data` grows.
+func resizeHashes*(a: var HashList) =
+  ## Ensure the hash cache is the correct size for the data in the list - must
+  ## be called whenever `data` shrinks or grows.
   let
     leaves = int(
       chunkIdx(a, a.data.len() + dataPerChunk(a.T) - 1))
     newSize = 1 + cacheNodes(a.maxDepth, leaves)
 
-  if a.hashes.len >= newSize:
+  # Growing might be because of add(), addDefault(), or in-place reading of a
+  # larger HashList. In-place reading of a smaller HashList causes shrinking.
+  if a.hashes.len == newSize:
     return
 
   var
-    newHashes = newSeq[Digest](newSize)
+    newHashes = newSeqWith(newSize, uninitSentinel)
     newIndices = default(type a.indices)
 
-  if a.hashes.len != newSize:
-    newIndices[0] = nodesAtLayer(0, a.maxDepth, leaves)
-    for i in 1..a.maxDepth:
-      newIndices[i] = newIndices[i - 1] + nodesAtLayer(i - 1, a.maxDepth, leaves)
+  newIndices[0] = nodesAtLayer(0, a.maxDepth, leaves)
+  for i in 1..a.maxDepth:
+    newIndices[i] =
+      newIndices[i - 1] + nodesAtLayer(i - 1, a.maxDepth, leaves)
 
-  for i in 1..<a.maxDepth:
-    for j in 0..<(a.indices[i] - a.indices[i-1]):
+  # When shrinking, truncate each layer
+  for i in 1 ..< a.maxDepth:
+    for j in 0 ..< min(
+        a.indices[i] - a.indices[i-1], newIndices[i] - newIndices[i - 1]):
       newHashes[newIndices[i - 1] + j] = a.hashes[a.indices[i - 1] + j]
 
   swap(a.hashes, newHashes)
@@ -339,7 +369,7 @@ func resetCache*(a: var HashList) =
   ## rewritten "manually" without going through the exported operators
   a.hashes.setLen(0)
   a.indices = default(type a.indices)
-  a.growHashes()
+  a.resizeHashes()
 
 func resetCache*(a: var HashArray) =
   for h in a.hashes.mitems():
@@ -349,7 +379,7 @@ template len*(a: type HashArray): auto = int(a.maxLen)
 
 func add*(x: var HashList, val: auto): bool =
   if add(x.data, val):
-    x.growHashes()
+    x.resizeHashes()
     clearCaches(x, x.data.len() - 1)
     true
   else:
@@ -360,13 +390,13 @@ func addDefault*(x: var HashList): ptr x.T =
     return nil
 
   distinctBase(x.data).setLen(x.data.len + 1)
-  x.growHashes()
+  x.resizeHashes()
   clearCaches(x, x.data.len() - 1)
   addr x.data[^1]
 
 template init*[T, N](L: type HashList[T, N], x: seq[T]): auto =
   var tmp = HashList[T, N](data: List[T, N].init(x))
-  tmp.growHashes()
+  tmp.resizeHashes()
   tmp
 
 template len*(x: HashList|HashArray): auto = len(x.data)
@@ -627,7 +657,6 @@ proc writeValue*(
 proc readValue*(reader: var JsonReader, value: var HashList)
                {.raises: [IOError, SerializationError].} =
   readValue(reader, value.data)
-  value.resetCache()
 
 template readValue*(reader: var JsonReader, value: var BitList) =
   type T = type(value)

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -9,13 +9,12 @@
 
 import
   std/[tables, typetraits, strformat],
-  stew/shims/macros, stew/[byteutils, bitops2, objects, results], stint,
+  stew/shims/macros, stew/[assign2, byteutils, bitops2, objects, results],
+  stint,
   nimcrypto/hash,
   serialization/[object_serialization, errors],
   json_serialization,
   "."/bitseqs
-
-from std/sequtils import newSeqWith
 
 from nimcrypto/utils import fromHex  # needed to disambiguate properly
 
@@ -350,8 +349,13 @@ func resizeHashes*(a: var HashList) =
     return
 
   var
-    newHashes = newSeqWith(newSize, uninitSentinel)
+    newHashes = newSeq[Digest](newSize)
     newIndices = default(type a.indices)
+
+  # newSeqWith already does this, just with potentially less efficient `=`
+  # rather than assign(): https://github.com/nim-lang/Nim/issues/22554
+  for i in 0 ..< newSize:
+    assign(newHashes[i], uninitSentinel)
 
   newIndices[0] = nodesAtLayer(0, a.maxDepth, leaves)
   for i in 1..a.maxDepth:

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -13,7 +13,7 @@ import
   nimcrypto/hash,
   serialization/[object_serialization, errors],
   json_serialization,
-  "."/[bitseqs]
+  "."/bitseqs
 
 from std/sequtils import newSeqWith
 


### PR DESCRIPTION
Quick, janky benchmark code:
```nim
import ./tests/consensus_spec/fixtures_utils
import std/sequtils
import ./beacon_chain/spec/forks
import std/monotimes
let c = readFile("state0.ssz")
let d = readFile("state1..ssz")

let e = mapIt(c, it.byte)
let f = mapIt(d, it.byte)

proc sszDecodeEntireInput2[T](input: openArray[byte], res: var T) =
  let stream = unsafeMemoryInput(input)
  var reader = init(SszReader, stream)
  reader.readValue(res)

var x, y, z: capella.BeaconState

# reference states
sszDecodeEntireInput2(e, x)
sszDecodeEntireInput2(f, y)

let aaa = hash_tree_root(x)
let bbb = hash_tree_root(y)

let a1 = getMonoTime()
sszDecodeEntireInput2(e, z)
let a2 = getMonoTime()
doAssert hash_tree_root(z) == aaa
let a3 = getMonoTime()
sszDecodeEntireInput2(f, z)
let a4 = getMonoTime()
doAssert hash_tree_root(z) == bbb
let a5 = getMonoTime()
sszDecodeEntireInput2(e, z)
let a6 = getMonoTime()
doAssert hash_tree_root(z) == aaa
let a7 = getMonoTime()
sszDecodeEntireInput2(e, z)
let a8 = getMonoTime()
doAssert hash_tree_root(z) == bbb
let a9 = getMonoTime()

echo "first (to fresh object) sDEI: ", (a2 - a1)
echo "first htr", (a3 - a2)
echo "second (in-place) sDEI", (a4 - a3)
echo "second htr (from updated object)", (a5 - a4)
echo "third sDEI (in-place, back to initial state)", (a6 - a5)
echo "third htr (of this in-place state revert)", (a7 - a6)
echo "fourth sDEI (in-place, back to second state)", (a8 - a7)
echo "fourth htr (back to second state)", (a9 - a8)
```

I got a recent head/finalized state pair from mainnet, which is approximately the main use case for this and thus representative.

With current `unstable`-pinned version:
```
first (to fresh object) sDEI: (seconds: 0, nanosecond: 37846517)
first htr(seconds: 0, nanosecond: 641582179)
second (in-place) sDEI(seconds: 0, nanosecond: 23082025)
second htr (from updated object)(seconds: 0, nanosecond: 639892914)
third sDEI (in-place, back to initial state)(seconds: 0, nanosecond: 22646981)
third htr (of this in-place state revert)(seconds: 0, nanosecond: 646745165)
fourth sDEI (in-place, back to second state)(seconds: 0, nanosecond: 24255788)
fourth htr (back to second state)(seconds: 0, nanosecond: 641245401)
```

Without fixed-size optimization:
```
first (to fresh object) sDEI: (seconds: 0, nanosecond: 37469790)
first htr(seconds: 0, nanosecond: 682701671)
second (in-place) sDEI(seconds: 0, nanosecond: 25305579)
second htr (from updated object)(seconds: 0, nanosecond: 693219500)
third sDEI (in-place, back to initial state)(seconds: 0, nanosecond: 27977029)
third htr (of this in-place state revert)(seconds: 0, nanosecond: 677372181)
fourth sDEI (in-place, back to second state)(seconds: 0, nanosecond: 27958591)
fourth htr (back to second state)(seconds: 0, nanosecond: 676574029)
```

With fixed-size optimization:
```
first (to fresh object) sDEI: (seconds: 0, nanosecond: 131054134)
first htr(seconds: 0, nanosecond: 684290575)
second (in-place) sDEI(seconds: 0, nanosecond: 25846644)
second htr (from updated object)(seconds: 0, nanosecond: 45835723)
third sDEI (in-place, back to initial state)(seconds: 0, nanosecond: 24004844)
third htr (of this in-place state revert)(seconds: 0, nanosecond: 46283060)
fourth sDEI (in-place, back to second state)(seconds: 0, nanosecond: 23035231)
fourth htr (back to second state)(seconds: 0, nanosecond: 46378324)
```

Factor of about 15x improvement on htr speed.

This isn't what the actual database reading code does -- it pieces to together immutable and immutable validator parts, while this handles the entire `Validator` in one place. But this is part of the approach which will handle that too.