### PR TITLE
Fix compiler complaining type mismatch for byte array

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -292,7 +292,7 @@ func cacheNodes*(depth, leaves: int): int =
 # matches this pattern, then it inefficiently recomputes some Merkle tree nodes
 # and still creates a correct result.
 const uninitSentinel = Digest(data: [
-  0, 0, 0, 0, 0, 0, 0, 0,
+  byte 0, 0, 0, 0, 0, 0, 0, 0,
   1, 1, 1, 1, 1, 1, 1, 1,
   1, 1, 1, 1, 1, 1, 1, 1,
   1, 1, 1, 1, 1, 1, 1, 1])


### PR DESCRIPTION
When bumping to latest nim-ssz-serialization in nimbus-eth1, this const is giving issues:

```
Building: build/fluffy
/Users/deme/repos/nimbus-eth1/vendor/nim-ssz-serialization/ssz_serialization/types.nim(294, 35) Error: type mismatch: got 'array[0..31, int]' for '[0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 1, 1, 1, 1, 1, 1]' but expected 'array[0..31, byte]'
```