### PR TITLE
workaround for Nim 2.0 issue with the template

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -615,9 +615,9 @@ func chunkedHashTreeRoot[T: BasicType](
 
   getFinalHash(merkleizer)
 
-template chunkedHashTreeRoot[T: not BasicType](
+func chunkedHashTreeRoot[T: not BasicType](
     merkleizer: var SszMerkleizerImpl, arr: openArray[T],
-    firstIdx, numFromFirst: Limit): Digest =
+    firstIdx, numFromFirst: Limit): Digest {.noinit.} =
   for i in 0 ..< numFromFirst:
     addChunkDirect(merkleizer):
       chunk = hash_tree_root(arr[firstIdx + i])


### PR DESCRIPTION
In Nim 2.0, getting

```
Error: type mismatch
Expression: `[]`(x, 0 + i`gensym1615)
  [1] x: array[0..63, Eth2Digest]
  [2] 0 + i`gensym1615: int
```

if `chunkedHashTreeRoot[T: not BasicType]` is a `template`. Aligning it to `func`, same as done for the `chunkedHashTreeRoot[T: BasicType`, fixes this.