### PR TITLE
use common super-type in `raisesssz` pragma

### DIFF
--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -6,7 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [SszError].}
 
 ## SSZ serialization for core SSZ types, as specified in:
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/ssz/simple-serialize.md#serialization
@@ -281,7 +280,8 @@ proc readValue*(
     # size of the dynamic portion to consume the right number of bytes.
     readSszBytes(r.stream.read(r.stream.len.get), val)
 
-proc readSszBytes*[T](data: openArray[byte], val: var T) {.raisesssz.} =
+proc readSszBytes*[T](
+    data: openArray[byte], val: var T) {.raises: [SszError].} =
   # Overload `readSszBytes` to perform custom operations on T after
   # deserialization
   mixin readSszValue

--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [MalformedSszError, SszSizeMismatchError].}
+{.pragma: raisesssz, raises: [SszError].}
 
 ## SSZ serialization for core SSZ types, as specified in:
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/ssz/simple-serialize.md#serialization
@@ -266,8 +266,8 @@ proc writeValue*[T](
   let length = toBytes(uint64(w.stream.pos - initPos), Leb128)
   cursor.finalWrite length.toOpenArray()
 
-proc readValue*(r: var SszReader, val: var auto) {.
-    raises: [MalformedSszError, SszSizeMismatchError, IOError].} =
+proc readValue*(
+    r: var SszReader, val: var auto) {.raises: [SszError, IOError].} =
   mixin readSszBytes
   type T = type val
   when isFixedSize(T):
@@ -281,8 +281,7 @@ proc readValue*(r: var SszReader, val: var auto) {.
     # size of the dynamic portion to consume the right number of bytes.
     readSszBytes(r.stream.read(r.stream.len.get), val)
 
-proc readSszBytes*[T](data: openArray[byte], val: var T) {.
-    raises: [MalformedSszError, SszSizeMismatchError].} =
+proc readSszBytes*[T](data: openArray[byte], val: var T) {.raisesssz.} =
   # Overload `readSszBytes` to perform custom operations on T after
   # deserialization
   mixin readSszValue

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [MalformedSszError, SszSizeMismatchError].}
+{.pragma: raisesssz, raises: [SszError].}
 
 # Coding and decoding of primitive SSZ types - every "simple" type passed to
 # and from the SSZ library must have a `fromSssBytes` and `toSszType` overload.

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -6,7 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [SszError].}
 
 # Coding and decoding of primitive SSZ types - every "simple" type passed to
 # and from the SSZ library must have a `fromSssBytes` and `toSszType` overload.
@@ -38,14 +37,15 @@ template setOutputSize[R, T](a: var array[R, T], length: int) =
   if length != a.len:
     raiseIncorrectSize a.type
 
-func setOutputSize(list: var List, length: int) {.raisesssz.} =
+func setOutputSize(list: var List, length: int) {.raises: [SszError].} =
   # We will overwrite all bytes
   if not list.setLenUninitialized length:
     raiseMalformedSszError(typeof(list), "length exceeds list limit")
 
 # fromSszBytes copies the wire representation to a Nim variable,
 # assuming there's enough data in the buffer
-func fromSszBytes*(T: type UintN, data: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type UintN, data: openArray[byte]): T {.raises: [SszError].} =
   ## Convert directly to bytes the size of the int. (e.g. ``uint16 = 2 bytes``)
   ## All integers are serialized as **little endian**.
   if data.len != sizeof(result):
@@ -53,13 +53,15 @@ func fromSszBytes*(T: type UintN, data: openArray[byte]): T {.raisesssz.} =
 
   T.fromBytesLE(data)
 
-func fromSszBytes*(T: type bool, data: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type bool, data: openArray[byte]): T {.raises: [SszError].} =
   # Strict: only allow 0 or 1
   if data.len != 1 or byte(data[0]) > byte(1):
     raiseMalformedSszError(bool, "invalid boolean value")
   data[0] == 1
 
-func fromSszBytes*(T: type Digest, data: openArray[byte]): T {.raisesssz, noinit.} =
+func fromSszBytes*(
+    T: type Digest, data: openArray[byte]): T {.raises: [SszError], noinit.} =
   if data.len != sizeof(result.data):
     raiseIncorrectSize T
   copyMem(result.data.addr, unsafeAddr data[0], sizeof(result.data))
@@ -234,11 +236,11 @@ macro initSszUnionImpl(RecordType: type, input: openArray[byte]): untyped =
 
   res
 
-func initSszUnion(T: type, input: openArray[byte]): T {.raisesssz.} =
+func initSszUnion(T: type, input: openArray[byte]): T {.raises: [SszError].} =
   initSszUnionImpl(T, input)
 
-proc readSszValue*[T](input: openArray[byte],
-                      val: var T) {.raisesssz.} =
+proc readSszValue*[T](
+    input: openArray[byte], val: var T) {.raises: [SszError].} =
   mixin fromSszBytes, toSszType
 
   template readOffsetUnchecked(n: int): uint32 {.used.}=

--- a/ssz_serialization/dynamic_navigator.nim
+++ b/ssz_serialization/dynamic_navigator.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [IOError, MalformedSszError, SszSizeMismatchError].}
+{.pragma: raisesssz, raises: [IOError, SszError].}
 
 import
   std/[strutils, parseutils],
@@ -109,7 +109,7 @@ func `[]`*(n: DynamicSszNavigator, idx: int): DynamicSszNavigator {.raisesssz.} 
   DynamicSszNavigator(m: n.typ.navigator(n.m, idx), typ: n.typ.elemType)
 
 func navigate*(n: DynamicSszNavigator, path: string): DynamicSszNavigator {.
-               raises: [KeyError, IOError, MalformedSszError, SszSizeMismatchError, ValueError] .} =
+               raises: [KeyError, IOError, SszError, ValueError] .} =
   case n.typ.kind
   of Record:
     let fieldInfo = n.typ.fields.findField(path)
@@ -136,11 +136,11 @@ template navigatePathImpl(nav, iterabalePathFragments: untyped) =
       return
 
 func navigatePath*(n: DynamicSszNavigator, path: string): DynamicSszNavigator {.
-                   raises: [IOError, ValueError, MalformedSszError, SszSizeMismatchError] .} =
+                   raises: [IOError, ValueError, SszError] .} =
   navigatePathImpl n, split(path, '/')
 
 func navigatePath*(n: DynamicSszNavigator, path: openArray[string]): DynamicSszNavigator {.
-                   raises: [IOError, ValueError, MalformedSszError, SszSizeMismatchError] .} =
+                   raises: [IOError, ValueError, SszError] .} =
   navigatePathImpl n, path
 
 func init*(T: type DynamicSszNavigator,

--- a/ssz_serialization/navigator.nim
+++ b/ssz_serialization/navigator.nim
@@ -6,7 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [SszError].}
 
 import
   stew/[ptrops, objects],
@@ -49,9 +48,10 @@ template checkBounds(m: MemRange, offset: int) =
 template toOpenArray(m: MemRange): auto =
   makeOpenArray(m.startAddr, m.length)
 
-func navigateToField*[T](n: SszNavigator[T],
-                         fieldName: static string,
-                         FieldType: type): SszNavigator[FieldType] {.raisesssz.} =
+func navigateToField*[T](
+    n: SszNavigator[T],
+    fieldName: static string,
+    FieldType: type): SszNavigator[FieldType] {.raises: [SszError].} =
   mixin toSszType
   type SszFieldType = type toSszType(declval FieldType)
 
@@ -83,7 +83,7 @@ template `.`*[T](n: SszNavigator[T], field: untyped): auto =
   type FieldType = type(default(RecType).field)
   navigateToField(n, astToStr(field), FieldType)
 
-func indexVarSizeList(m: MemRange, idx: int): MemRange {.raisesssz.} =
+func indexVarSizeList(m: MemRange, idx: int): MemRange {.raises: [SszError].} =
   template readOffset(pos): int =
     int fromSszBytes(uint32, makeOpenArray(offset(m.startAddr, pos), offsetSize))
 
@@ -130,7 +130,7 @@ template `[]`*[T](n: SszNavigator[seq[T]], idx: int): SszNavigator[T] =
 template `[]`*[R, T](n: SszNavigator[array[R, T]], idx: int): SszNavigator[T] =
   indexList(n, idx, T)
 
-func `[]`*[T](n: SszNavigator[T]): T {.raisesssz.} =
+func `[]`*[T](n: SszNavigator[T]): T {.raises: [SszError].} =
   mixin toSszType, fromSszBytes
   type SszRepr = type toSszType(declval T)
   when type(SszRepr) is type(T) or T is List:
@@ -138,5 +138,5 @@ func `[]`*[T](n: SszNavigator[T]): T {.raisesssz.} =
   else:
     fromSszBytes(T, toOpenArray(n.m))
 
-converter derefNavigator*[T](n: SszNavigator[T]): T {.raisesssz.} =
+converter derefNavigator*[T](n: SszNavigator[T]): T {.raises: [SszError].} =
   n[]

--- a/ssz_serialization/navigator.nim
+++ b/ssz_serialization/navigator.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [MalformedSszError, SszSizeMismatchError].}
+{.pragma: raisesssz, raises: [SszError].}
 
 import
   stew/[ptrops, objects],
@@ -140,4 +140,3 @@ func `[]`*[T](n: SszNavigator[T]): T {.raisesssz.} =
 
 converter derefNavigator*[T](n: SszNavigator[T]): T {.raisesssz.} =
   n[]
-


### PR DESCRIPTION
With the current `[MalformedSszError, SszSizeMismatchError]` definition for `{.pragma: raisesssz.}`, a lot of `XCannotRaiseY` are sometimes generated when a concrete implementation does not actually raise all of the potential errors. Declaring `{.pragma: raisessz.}` to raise common `[SszError]` instead has the same semantics but reduces spurious hints.