### PR TITLE
simplify implementation, more zeroMem fixes

### DIFF
--- a/tests/test_hash_tree_root.nim
+++ b/tests/test_hash_tree_root.nim
@@ -1,6 +1,6 @@
+{.used.}
+
 import
-  unittest2,
-  stew/byteutils,
   ../ssz_serialization/merkleization
 
 type
@@ -42,6 +42,6 @@ proc main() =
   var h: ExecutionPayload
   # under nim 1.6.12, hash_tree_root failed to compile
   # but the bug fixed in nim > 1.6.14
-  let z = hash_tree_root(h)
+  let z {.used.} = hash_tree_root(h)
 
 main()


### PR DESCRIPTION
This PR removes the remaining significant temporaries, zeroMems and copies in the implemenation and improves general code safety by removing some of the pointer tricks used.

Although this introduces some code bloat due to parts of the implementation ending up being more generic, this also opens up tracking limits and fixing a number of issues involving writing past it.