### PR TITLE
Fix error on decoding of an empty list in an SSZ Union

### DIFF
--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -225,9 +225,6 @@ macro initSszUnionImpl(RecordType: type, input: openArray[byte]): untyped =
 
           enumInstanceSerializedFields(caseObj, fieldName, field):
             when fieldName != `SelectorFieldNameLit`:
-              if `input`.len <= 1:
-                raiseMalformedSszError(`type recordDef`, "invalid empty for selector")
-
               readSszValue(`input`.toOpenArray(1, `input`.len - 1), field)
 
           caseObj

--- a/tests/test_ssz_union.nim
+++ b/tests/test_ssz_union.nim
@@ -112,6 +112,19 @@ suite "SSZ Union serialization":
         test.selector == decoded.selector
         test.variableObj == decoded.variableObj
 
+  test "Union with empty list":
+    let test = TestCaseObject(selector: SomeVariable,
+      variablePart: List[byte, 16](@[]))
+    let encoded = SSZ.encode(test)
+
+    check encoded.toHex() == "03"
+
+    let decoded = SSZ.decode(encoded, TestCaseObject)
+
+    check:
+      test.selector == decoded.selector
+      test.variablePart == decoded.variablePart
+
 suite "SSZ Union invalid inputs":
   test "No data":
     var encoded: seq[byte]


### PR DESCRIPTION
This removes a check that was (probably) there to verify if the input data had more than just the selector byte so that it wouldn't indicate a `None`. However, there is  also the case of an empty SSZ.List that encoded as 0 bytes.

This does sound a bit strange as the potential None value in an SSZ Union also has 0 bytes, but both cases can be decoded properly as a None is defined by having no field (which is checked at compile time).