### PR TITLE
more fixes for `distinct` integer types

### DIFF
--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -272,7 +272,7 @@ proc writeValue*[T](
 proc readValue*(
     r: var SszReader, val: var auto) {.raises: [SszError, IOError].} =
   mixin readSszBytes
-  type T = type val
+  type T = typeof val
   when isFixedSize(T):
     const minimalSize = fixedPortionSize(T)
     if r.stream.readable(minimalSize):
@@ -288,5 +288,5 @@ proc readSszBytes*[T](
     data: openArray[byte], val: var T) {.raises: [SszError].} =
   # Overload `readSszBytes` to perform custom operations on T after
   # deserialization
-  mixin readSszValue
-  readSszValue(data, val)
+  mixin readSszValue, toSszType
+  readSszValue(data, toSszType(val))

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -279,7 +279,7 @@ proc readSszValue*[T](
       checkForForbiddenBits(T, input, val.maxLen + 1)
 
   elif val is HashList:
-    type E = typeof toSszType(declVal ElemType(typeof val))
+    type E = typeof toSszType(declval ElemType(typeof val))
 
     when isFixedSize(E):
       const elemSize = fixedPortionSize(E)
@@ -366,7 +366,7 @@ proc readSszValue*[T](
   elif val is Digest:
     readSszValue(input, val.data)
   elif val is List|array:
-    type E = typeof toSszType(declVal ElemType(typeof val))
+    type E = typeof toSszType(declval ElemType(typeof val))
 
     when isFixedSize(E):
       const elemSize = fixedPortionSize(E)
@@ -412,10 +412,12 @@ proc readSszValue*[T](
         if nextOffset < offset:
           raiseMalformedSszError(T, "list element offsets are decreasing")
         else:
-          readSszValue(input.toOpenArray(offset, nextOffset - 1), val[i - 1])
+          readSszValue(
+            input.toOpenArray(offset, nextOffset - 1), toSszType(val[i - 1]))
         offset = nextOffset
 
-      readSszValue(input.toOpenArray(offset, input.len - 1), val[resultLen - 1])
+      readSszValue(
+        input.toOpenArray(offset, input.len - 1), toSszType(val[resultLen - 1]))
 
   elif val is OptionalType:
     type E = ElemType(T)

--- a/ssz_serialization/dynamic_navigator.nim
+++ b/ssz_serialization/dynamic_navigator.nim
@@ -1,5 +1,5 @@
 # ssz_serialization
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -86,7 +86,7 @@ proc typeInfo*(T: type): TypeInfo =
 
 func genTypeInfo(T: type): TypeInfo =
   mixin toSszType, enumAllSerializedFields
-  type SszType = type toSszType(declval T)
+  type SszType = type toSszType(default T)
   result = when type(SszType) isnot T:
     TypeInfo(kind: LeafValue)
   elif T is object:

--- a/ssz_serialization/navigator.nim
+++ b/ssz_serialization/navigator.nim
@@ -1,5 +1,5 @@
 # ssz_serialization
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -53,7 +53,7 @@ func navigateToField*[T](
     fieldName: static string,
     FieldType: type): SszNavigator[FieldType] {.raises: [SszError].} =
   mixin toSszType
-  type SszFieldType = type toSszType(declval FieldType)
+  type SszFieldType = type toSszType(default FieldType)
 
   const boundingOffsets = getFieldBoundingOffsets(T, fieldName)
   checkBounds(n.m, boundingOffsets[1])

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -65,7 +65,13 @@ func nextPow2Int64(x: int64): int64 =
 
 template dataPerChunk(T: type): int =
   # How many data items fit in a chunk
-  when T is BasicType:
+  mixin toSszType
+  const isCompressed =
+    when compiles(toSszType(declval T)):
+      (typeof toSszType(declval T)) is BasicType
+    else:
+      T is BasicType
+  when isCompressed:
     bytesPerChunk div sizeof(T)
   else:
     1
@@ -512,7 +518,7 @@ func supportsBulkCopy*(T: type): bool {.compileTime.} =
 func isFixedSize*(T0: type): bool {.compileTime.} =
   mixin toSszType, enumAllSerializedFields
 
-  type T = type toSszType(declval T0)
+  type T = type toSszType(default T0)
 
   when T is BasicType:
     return true


### PR DESCRIPTION
Applying `toSszType` in more places allows simple case `distinct uint64` to work properly. Complex scenarios where the `toSszType` helper returns a `BasicType` of different size than original are still unsupported.