### PR TITLE
update ci.yml and fix deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,11 @@ jobs:
             cpu: arm64
           - os: windows
             cpu: amd64
-          #- os: windows
-            #cpu: i386
         branch: [version-1-6, version-2-0, devel]
         include:
           - target:
               os: linux
-            builder: ubuntu-22.04
+            builder: ubuntu-latest
             shell: bash
           - target:
               os: macos
@@ -43,11 +41,11 @@ jobs:
               os: macos
               cpu: arm64
             # On macos-14, we get an M1 cpu
-            builder: macos-14
+            builder: macos-latest
             shell: bash
           - target:
               os: windows
-            builder: windows-2019
+            builder: windows-latest
             shell: msys2 {0}
 
     defaults:
@@ -59,7 +57,7 @@ jobs:
     continue-on-error: ${{ matrix.branch == 'devel' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -107,7 +105,7 @@ jobs:
       - name: Restore Nim DLLs dependencies (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-dlls-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: external/dlls-${{ matrix.target.cpu }}
           key: 'dlls-${{ matrix.target.cpu }}'
@@ -173,15 +171,8 @@ jobs:
           nim --version
           nimble --version
           nimble install -y --depsOnly
-          if [[ "${{ matrix.branch }}" == "version-1-6" ]]; then
-            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
-            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
-          else
-            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
-            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
-            env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
-            env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
-          fi
+          env TEST_LANG="c" NIMFLAGS="${NIMFLAGS}" nimble test
+          env TEST_LANG="cpp" NIMFLAGS="${NIMFLAGS}" nimble test
 
       - name: Fuzz a little
         if: runner.os == 'Linux' && matrix.target.cpu == 'amd64'

--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -12,7 +12,8 @@
 
 import
   std/[options, typetraits],
-  stew/[endians2, leb128, objects, ptrops, results],
+  results,
+  stew/[endians2, leb128, objects, ptrops],
   serialization, serialization/testing/tracing,
   ./ssz_serialization/[codec, bitseqs, types]
 

--- a/ssz_serialization.nimble
+++ b/ssz_serialization.nimble
@@ -14,6 +14,7 @@ requires "nim >= 1.6.0",
          "stint",
          "nimcrypto",
          "blscurve",
+         "results",
          "unittest2"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
@@ -33,17 +34,17 @@ proc build(args, path: string) =
   exec nimc & " " & lang & " " & cfg & " " & flags & " " & args & " " & path
 
 proc run(args, path: string) =
-  build args & " -r", path
+  build args & " --mm:refc -r", path
   if (NimMajor, NimMinor) > (1, 6):
-    build args & " --mm:refc -r", path
+    build args & " --mm:orc -r", path
 
 task test, "Run all tests":
   for blst in [false, true]:
     for hashtree in [false, true]:
       let opts = "--threads:on -d:PREFER_BLST_SHA256=" & $blst & " -d:PREFER_HASHTREE_SHA256=" & $hashtree
-      run opts, "tests/test_all"
+      run "--mm:refc " & opts, "tests/test_all"
       if (NimMajor, NimMinor) > (1, 6):
-        run "--mm:refc " & opts, "tests/test_all"
+        run "--mm:orc " & opts, "tests/test_all"
 
 task fuzzHashtree, "Run fuzzing test":
   # TODO We don't run because the timeout parameter doesn't seem to work so

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -12,7 +12,8 @@
 
 import
   std/typetraits,
-  stew/[endians2, objects, results], stew/shims/macros,
+  results,
+  stew/[endians2, objects], stew/shims/macros,
   ./types
 
 from stew/assign2 import assign

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -18,7 +18,8 @@
 
 import
   std/[algorithm, options, sequtils],
-  stew/[assign2, bitops2, endians2, objects, ptrops, results],
+  stew/[assign2, bitops2, endians2, objects, ptrops],
+  results,
   nimcrypto/[hash, sha2],
   serialization/testing/tracing,
   "."/[bitseqs, codec, digest, types]

--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -9,7 +9,8 @@
 
 import
   std/[algorithm, math, sequtils, sets, tables],
-  stew/[bitops2, results],
+  results,
+  stew/[bitops2],
   "."/[digest, merkleization]
 
 export digest, merkleization

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -9,7 +9,8 @@
 
 import
   std/[tables, typetraits, strformat],
-  stew/shims/macros, stew/[assign2, byteutils, bitops2, objects, results],
+  stew/shims/macros, stew/[assign2, byteutils, bitops2, objects],
+  results,
   stint,
   nimcrypto/hash,
   serialization/[object_serialization, errors],


### PR DESCRIPTION
This is a milder version of https://github.com/status-im/nim-ssz-serialization/pull/89 — it keeps Nim 1.6 support.