### PR TITLE
fix distinct BasicType compressed detection in dataPerChunk

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -1,5 +1,5 @@
 # ssz_serialization
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -68,7 +68,7 @@ template dataPerChunk(T: type): int =
   # How many data items fit in a chunk
   mixin toSszType
   const isCompressed =
-    when compiles(toSszType(declval T)):
+    when compiles(typeof toSszType(declval T)):
       (typeof toSszType(declval T)) is BasicType
     else:
       T is BasicType

--- a/tests/test_merkleization.nim
+++ b/tests/test_merkleization.nim
@@ -70,6 +70,9 @@ let cases = (
   TestData[16](count: 9, expectedRoot: h(h(h(h(e(0), e(1)), h(e(2), e(3))), h(h(e(4), e(5)), h(e(6), e(7)))), h(h(h(e(8), z(0)), z(1)), z(2))))
 )
 
+type U = distinct uint64
+template toSszType(v: U): auto = uint64(v)
+
 suite "Merkleization":
   test "Calculate correct root from provided chunks":
     for testCase in cases.fields:
@@ -84,3 +87,7 @@ suite "Merkleization":
       let calculatedRoot = merk.getFinalHash()
 
       check calculatedRoot.data.toSeq() == testCase.expectedRoot
+
+  test "Calculate correct root using distinct BasicType":
+    check: hash_tree_root(default(List[U, 2])) ==
+      hash_tree_root(default(List[uint64, 2]))


### PR DESCRIPTION
`declval` is only supposed to be used in a `type`/`typeof`-ish expression. It was not here, but through Nim 2.0.8 that had been allowed. Nim 2.0.10 notices this and properly responds `false` to that `compiles(...)` otherwise.