### PR TITLE
rm unused code

### DIFF
--- a/ssz_serialization.nim
+++ b/ssz_serialization.nim
@@ -80,10 +80,6 @@ proc writeFixedSized(s: var (OutputStream|WriteCursor), x: auto) {.raises: [IOEr
 template writeOffset(cursor: var WriteCursor, offset: int) =
   write cursor, toBytesLE(uint32 offset)
 
-template supports*(_: type SSZ, T: type): bool =
-  mixin toSszType
-  anonConst compiles(fixedPortionSize toSszType(declval T))
-
 func init*(T: type SszWriter, stream: OutputStream): T =
   result.stream = stream
 


### PR DESCRIPTION
To start with, it doesn't work right now:

```nim
import ssz_serialization
echo SSZ.supports(uint64)   # is false
```
in Nim 2.0.8 prints `false`, for example.

https://github.com/status-im/nimbus-eth2/pull/6573#issuecomment-2380849645 has more context -- essentially `compiles( ... declval ...)` behaves a bit oddly at times.

Nothing either in `nim-ssz-serialization` or `nimbus-eth2` uses it, either.

If people truly want this functionality, it can be reintroduced and reviewed as new code in a separate PR, but it's more important to remove the broken dependent on questionable assumptions which vary depending on all three of `(NimMajor, NimMinor, NimPatch)`.