### PR TITLE
Add `maxSize` helper

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -561,6 +561,34 @@ func fixedPortionSize*(T0: type): int {.compileTime.} =
   else:
     unsupported T0
 
+func maxSize*(T0: type): int {.compileTime.} =
+  mixin enumAllSerializedFields, toSszType
+
+  type T = type toSszType(declval T0)
+
+  when isFixedSize(T):
+    fixedPortionSize(T)
+  elif T is array|HashArray:
+    type E = ElemType(T)
+    static: doAssert not isFixedSize(E)
+    T.len * (offsetSize + maxSize(E))
+  elif T is List|HashList:
+    type E = ElemType(T)
+    when isFixedSize(E):
+      T.maxLen * fixedPortionSize(E)
+    else:
+      T.maxLen * (offsetSize + maxSize(E))
+  elif T is BitList:
+    ((T.maxLen + 1) + 7) div 8
+  elif T is object:
+    var res = fixedPortionSize(T)
+    enumAllSerializedFields(T):
+      when not isFixedSize(FieldType):
+        res += maxSize(FieldType)
+    res
+  else:
+    unsupported T0
+
 iterator fieldInfos(RecordType: type): tuple[name: string,
                                              offset: int,
                                              fixedSize: int,

--- a/tests/test_ssz_serialization.nim
+++ b/tests/test_ssz_serialization.nim
@@ -53,13 +53,28 @@ static:
   doAssert fixedPortionSize(array[SomeEnum, DistinctInt]) == 24
   doAssert fixedPortionSize(array[3..5, List[byte, 256]]) == 12
 
+  doAssert maxSize(array[10, bool]) == 10
+  doAssert maxSize(array[SomeEnum, uint64]) == 24
+  doAssert maxSize(array[SomeEnum, DistinctInt]) == 24
+  doAssert maxSize(array[3..5, List[byte, 256]]) == 3 * (4 + 256)
+
   doAssert isFixedSize(array[20, bool]) == true
   doAssert isFixedSize(Simple) == true
   doAssert isFixedSize(List[bool, 128]) == false
 
+  doAssert maxSize(array[20, bool]) == 20
+  doAssert maxSize(Simple) == 1 + 256 + 256
+  doAssert maxSize(List[bool, 128]) == 128
+
   doAssert isFixedSize(NonFixed) == false
 
+  doAssert maxSize(NonFixed) == 4 + 1024 * 8
+
+  doAssert maxSize(HashList[BitList[24], 20]) == 20 * (4 + 4)
+  doAssert maxSize(HashList[NonFixed, 20]) == 20 * (4 + (4 + 1024 * 8))
+
   reject fixedPortionSize(int)
+  reject maxSize(int)
 
 type
   ObjWithFields = object


### PR DESCRIPTION
As requested in #20, add a helper to compute maximum theoretical length of an SSZ object. Note that there is an extra limit of 4GB due to offset size that is not considered by the function.