### PR TITLE
Add `minSize` helper

### DIFF
--- a/tests/test_ssz_serialization.nim
+++ b/tests/test_ssz_serialization.nim
@@ -53,6 +53,11 @@ static:
   doAssert fixedPortionSize(array[SomeEnum, DistinctInt]) == 24
   doAssert fixedPortionSize(array[3..5, List[byte, 256]]) == 12
 
+  doAssert minSize(array[10, bool]) == 10
+  doAssert minSize(array[SomeEnum, uint64]) == 24
+  doAssert minSize(array[SomeEnum, DistinctInt]) == 24
+  doAssert minSize(array[3..5, List[byte, 256]]) == 3 * 4
+
   doAssert maxSize(array[10, bool]) == 10
   doAssert maxSize(array[SomeEnum, uint64]) == 24
   doAssert maxSize(array[SomeEnum, DistinctInt]) == 24
@@ -62,18 +67,30 @@ static:
   doAssert isFixedSize(Simple) == true
   doAssert isFixedSize(List[bool, 128]) == false
 
+  doAssert minSize(array[20, bool]) == 20
+  doAssert minSize(Simple) == 1 + 256 + 256
+  doAssert minSize(List[bool, 128]) == 0
+
   doAssert maxSize(array[20, bool]) == 20
   doAssert maxSize(Simple) == 1 + 256 + 256
   doAssert maxSize(List[bool, 128]) == 128
 
   doAssert isFixedSize(NonFixed) == false
 
+  doAssert minSize(NonFixed) == 4
+
   doAssert maxSize(NonFixed) == 4 + 1024 * 8
 
+  doAssert minSize(array[20, BitList[24]]) == 20 * (4 + 1)
+  doAssert minSize(HashList[BitList[24], 20]) == 0
+  doAssert minSize(HashList[NonFixed, 20]) == 0
+
+  doAssert maxSize(array[20, BitList[24]]) == 20 * (4 + 4)
   doAssert maxSize(HashList[BitList[24], 20]) == 20 * (4 + 4)
   doAssert maxSize(HashList[NonFixed, 20]) == 20 * (4 + (4 + 1024 * 8))
 
   reject fixedPortionSize(int)
+  reject minSize(int)
   reject maxSize(int)
 
 type


### PR DESCRIPTION
Introduces `minSize` as a counterpart to `maxSize` (#20).