### PR TITLE
fix compiler warnings

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -196,7 +196,10 @@ func setLenUninitialized*(x: var List, newLen: int): bool =
     # TODO https://github.com/nim-lang/Nim/issues/19727
     when List.T is SomeNumber:
       if x.len !=  newLen:
-        distinctBase(x) = newSeqUninitialized[x.T](newLen)
+        distinctBase(x) = when (NimMajor, NimMinor) < (2, 2):
+                            newSeqUninitialized[x.T](newLen)
+                          else:
+                            newSeqUninit[x.T](newLen)
     else:
       setLen(distinctBase(x), newLen)
     true

--- a/tests/test_proofs.nim
+++ b/tests/test_proofs.nim
@@ -9,7 +9,7 @@
 
 import
   std/sequtils,
-  stew/[bitops2, byteutils, staticfor],
+  stew/[bitops2, staticfor],
   unittest2,
   ../ssz_serialization/proofs
 


### PR DESCRIPTION
- Warning: Use `newSeqUninit` instead; newSeqUninitialized is deprecated
- Warning: imported and not used: 'byteutils'