### PR TITLE
bump hashtree to not need CPU-agnostic fallback

### DIFF
--- a/ssz_serialization/digest.nim
+++ b/ssz_serialization/digest.nim
@@ -145,6 +145,3 @@ func digest*(a, b: openArray[byte], res: var Digest) =
 
 func digest*(a, b: openArray[byte]): Digest {.noinit.} =
   digest(a, b, result)
-
-when USE_HASHTREE_SHA256:
-  hashtree_init(nil)


### PR DESCRIPTION
- https://github.com/OffchainLabs/hashtree/pull/42
- https://github.com/OffchainLabs/hashtree/pull/43

This version of `hashtree` contains its own C fallback, so don't need the local one in `nim-ssz-serialization`.