### PR TITLE
Fix indexAt for maximum layer

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -680,10 +680,13 @@ template indexAt(i: int): GeneralizedIndex =
   block:
     let v = indices[loopOrder[i]]
     if atLayer != 0:
-      let
-        n = leadingZeros(v) + 1 + atLayer
-        x = ((v shl n) or 1.GeneralizedIndex).GeneralizedIndex
-      rotateRight(x, n)
+      let n = leadingZeros(v) + 1 + atLayer
+      if n < 64:
+        let x = ((v shl n) or 1.GeneralizedIndex).GeneralizedIndex
+        rotateRight(x, n)
+      else:  # `v shl 64` doesn't shift and silently becomes a noop
+        doAssert n == 64
+        1.GeneralizedIndex
     else:
       v
 


### PR DESCRIPTION
Trying to use `indexAt` at maximum depth incorrectly does `or 1` instead of simply returning `1.GeneralizedIndex` due to incorrect assumption about how `shl` works in Nim. Handle `shl 64` manually.