### PR TITLE
`readSszBytes` overload should be used for nested objects also

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,4 +1,0 @@
-# begin Nimble config (version 1)
-when fileExists("nimble.paths"):
-  include "nimble.paths"
-# end Nimble config


### PR DESCRIPTION
Otherwise, overloading works only for the top-level call which is surprising.