### PR TITLE
Change HashSeq API to match HashList

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -687,7 +687,7 @@ func addDefault*(x: var HashList): ptr x.T =
   clearCaches(x, x.data.len() - 1)
   addr x.data[^1]
 
-func add*(x: var HashSeq, val: auto): bool =
+func add*(x: var HashSeq, val: auto): bool {.discardable.} =
   add(x.data, val)
   x.resizeHashes()
   if x.data.len() > 0:

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -661,6 +661,11 @@ func resetCache*(a: var HashSeq) =
   a.indices.reset()
   a.resizeHashes()
 
+func clearCache*(a: var HashSeq) =
+  clearCache(a.root)
+  for level in a.hashes.mitems():
+    clearCache(level)
+
 template len*(a: type HashArray): auto = int(a.maxLen)
 
 func add*(x: var HashList, val: auto): bool =
@@ -682,12 +687,13 @@ func addDefault*(x: var HashList): ptr x.T =
   clearCaches(x, x.data.len() - 1)
   addr x.data[^1]
 
-func add*(x: var HashSeq, val: auto) =
+func add*(x: var HashSeq, val: auto): bool =
   add(x.data, val)
   x.resizeHashes()
   if x.data.len() > 0:
     # Otherwise, adding an empty list to an empty list fails
     clearCaches(x, x.data.len() - 1)
+  true
 
 func addDefault*(x: var HashSeq): ptr x.T =
   distinctBase(x.data).setLen(x.data.len + 1)

--- a/tests/test_hashcache.nim
+++ b/tests/test_hashcache.nim
@@ -67,20 +67,16 @@ template runHashCacheTests[T](_: typedesc[T]): untyped =
 
   test "Incremental add":
     for i in 0 ..< 100:
-      when items is HashList:
-        check items.add(foo)
-      else:
+      check:
         items.add(foo)
-      check items.hash_tree_root() == items.data.hash_tree_root()
+        items.hash_tree_root() == items.data.hash_tree_root()
 
   test "Incremental add across cache depth boundary":
     items.checkResize(1020)
     for i in 1020 ..< 1080:
-      when items is HashList:
-        check items.add(foo)
-      else:
+      check:
         items.add(foo)
-      check items.hash_tree_root() == items.data.hash_tree_root()
+        items.hash_tree_root() == items.data.hash_tree_root()
 
   test "Incremental decrease":
     for i in countdown(1050, 0):
@@ -106,11 +102,9 @@ template runHashCacheTests[T](_: typedesc[T]): untyped =
         else:
           true
       if canAdd and rand(1) == 0:
-        when items is HashList:
-          check items.add(foo)
-        else:
+        check:
           items.add(foo)
-        check items.hash_tree_root() == items.data.hash_tree_root()
+          items.hash_tree_root() == items.data.hash_tree_root()
       else:
         let count =
           when items is HashList:

--- a/tests/test_ssz_serialization.nim
+++ b/tests/test_ssz_serialization.nim
@@ -190,11 +190,9 @@ suite "HashList":
       var leaves: typ.listImpl
       while leaves.len < maxLen:
         checkpoint $typ & " - " & $leaves.len
-        when leaves is HashSeq:
+        check:
           leaves.add leaves.len.typ
-        else:
-          check leaves.add leaves.len.typ
-        check hash_tree_root(leaves) == hash_tree_root(leaves.data)
+          hash_tree_root(leaves) == hash_tree_root(leaves.data)
 
     checkType uint64
     checkType DistinctInt
@@ -269,16 +267,10 @@ suite "hash":
         emptyBytes = SSZ.encode(small)
         emptyRoot = hash_tree_root(small)
 
-      when MyList is HashSeq:
-        small.add(10.typ)
-      else:
-        check small.add(10.typ)
+      check small.add(10.typ)
 
       for i in 0..<100:
-        when MyList is HashSeq:
-          large.add(i.typ)
-        else:
-          check large.add(i.typ)
+        check large.add(i.typ)
 
       let
         sroot = hash_tree_root(small)
@@ -335,16 +327,10 @@ suite "hash":
       emptyBytes = SSZ.encode(small)
       emptyRoot = hash_tree_root(small)
 
-    when MyList is HashSeq:
-      small.add(NonFixed())
-    else:
-      check small.add(NonFixed())
+    check small.add(NonFixed())
 
     for i in 0..<100:
-      when MyList is HashSeq:
-        large.add(NonFixed())
-      else:
-        check large.add(NonFixed())
+      check large.add(NonFixed())
 
     let
       sroot = hash_tree_root(small)


### PR DESCRIPTION
To simplify interoperability of HashList / HashSeq (e.g., across forks), update HashSeq APIs to match the signature of HashList, i.e.:

- bool return for `add`
- clearCache to clear cache without reallocating seqs.