### PR TITLE
Fix mitem on single-chunk HashList

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -495,8 +495,8 @@ func clearCachesList[T, I](
     return
 
   var
-    idx = 1'i64 shl (depth - 1) + (chunkIdx(t, dataIdx) shr 1)
-    layer = depth - 1
+    layer = max(depth - 1, 0)
+    idx = 1'i64 shl layer + (chunkIdx(t, dataIdx) shr 1)
   while idx > 0:
     let
       idxInLayer = idx - (1'i64 shl layer)

--- a/tests/test_hashcache.nim
+++ b/tests/test_hashcache.nim
@@ -116,6 +116,24 @@ template runHashCacheTests[T](_: typedesc[T]): untyped =
 suite "HashList":
   runHashCacheTests(HashList[Foo, 8192])
 
+suite "HashList mutation":
+  template runMutationTests(maxLen: static Limit): untyped =
+    test "Mutate elements after hashing - " & $maxLen:
+      var hl: HashList[Foo, maxLen]
+      for i in 0 ..< int(maxLen):
+        check:
+          hl.add(foo)
+          hl.hash_tree_root() == hl.data.hash_tree_root()
+        for j in 0 ..< hl.data.len:
+          hl.mitem(j).y = uint64(1000 + i * 100 + j)
+          check hl.hash_tree_root() == hl.data.hash_tree_root()
+
+  runMutationTests(1)
+  runMutationTests(2)
+  runMutationTests(3)
+  runMutationTests(4)
+  runMutationTests(8)
+
 suite "HashSeq":
   runHashCacheTests(HashSeq[Foo])
 


### PR DESCRIPTION
Modifying the single chunk of a HashList that only has a single chunk (i.e., single Container, 4x uint64 etc) skips cache invalidation. Handle that case to improve robustness.

This used to be also broken for HashArray, fixed in #163. Originally created in https://github.com/status-im/nimbus-eth2/pull/1084