### PR TITLE
Fix growing from empty HashList (shallow tree)

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -537,7 +537,7 @@ func resizeHashes[T, I](
   ## be called whenever `data` shrinks or grows.
   let
     leaves = int(chunkIdx(T, dataLen + dataPerChunk(T) - 1))
-    newSize = 1 + max(cacheNodes(depth, leaves), 1)
+    newSize = 1 + cacheNodes(max(depth, 1), leaves)
 
   # Growing might be because of add(), addDefault(), or in-place reading of a
   # larger HashList. In-place reading of a smaller HashList causes shrinking.

--- a/tests/test_hashcache.nim
+++ b/tests/test_hashcache.nim
@@ -128,6 +128,29 @@ suite "HashList mutation":
           hl.mitem(j).y = uint64(1000 + i * 100 + j)
           check hl.hash_tree_root() == hl.data.hash_tree_root()
 
+    test "Add after empty read - " & $maxLen:
+      var hl: HashList[Foo, maxLen]
+      try:
+        readSszBytes(@[], hl)
+      except SszError:
+        raiseAssert "Valid SSZ"
+      for i in 0 ..< int(maxLen):
+        check:
+          hl.add(foo)
+          hl.hash_tree_root() == hl.data.hash_tree_root()
+
+    test "Resize via read - " & $maxLen:
+      var hl: HashList[Foo, maxLen]
+      for i, len in [
+          0, 0, int(maxLen), int(maxLen), 0, 1, 1, int(maxLen), 0, 0, 1]:
+        let contents = (0 ..< len).mapIt(
+          Foo(x: foo.x, y: uint64(1000 * (i + 1) + it)))
+        try:
+          readSszBytes(SSZ.encode(contents), hl)
+        except SszError:
+          raiseAssert "Valid SSZ"
+        check hl.hash_tree_root() == hl.data.hash_tree_root()
+
   runMutationTests(1)
   runMutationTests(2)
   runMutationTests(3)


### PR DESCRIPTION
Loading an empty HashList, then adding the first items incrementally does not properly resize the cache as the empty HashList and the single chunk HashList share the same cache hashes.len for shallow trees.

Regression from #108, but that fix is still relevant. We just have to make sure that the leaves == 0 case is correct as well.