### PR TITLE
Invalidate cache when filling HashArray

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -424,6 +424,8 @@ template maxChunks*(a: HashList|HashArray): int64 =
   ## Layer where data is
   const v = maxChunkIdx(a.T, a.maxLen) # force compile-time eval
   static: doAssert (v mod 2 == 0) or (v == 1)
+  when a is HashArray:
+    static: doAssert v > 0, "HashArray must have a non-zero length"
   v
 
 template maxDepth*(a: HashList|HashArray): int =
@@ -809,6 +811,8 @@ template clear*(a: var HashSeq) =
 template fill*(a: var HashArray, c: auto) =
   mixin fill
   fill(a.data, c)
+  a.resetCache()
+
 template sum*[maxLen; T](a: var HashArray[maxLen, T]): T =
   mixin sum
   sum(a.data)

--- a/tests/test_hashcache.nim
+++ b/tests/test_hashcache.nim
@@ -9,7 +9,7 @@
 {.used.}
 
 import
-  std/[random, sequtils],
+  std/[algorithm, random, sequtils],
   stew/byteutils,
   unittest2,
   ../ssz_serialization,
@@ -211,6 +211,15 @@ suite "HashArray":
         for i in 0 ..< numItems:
           ha.mitem(i).reset()
         check ha.hash_tree_root() == ha.data.hash_tree_root()
+
+    test "Fill after hashing - " & $maxLen:
+      var ha: HashArray[maxLen, Foo]
+      for i in 0 ..< int(maxLen):
+        ha.mitem(i) = foo
+        ha.mitem(i).x.data[0] = i.byte
+      check ha.hash_tree_root() == ha.data.hash_tree_root()
+      ha.fill(foo)
+      check ha.hash_tree_root() == ha.data.hash_tree_root()
 
   runHashArrayTests(1)
   runHashArrayTests(2)


### PR DESCRIPTION
HashArray has a fill function but it doesn't invalidate the cache. Introduced back in https://github.com/status-im/nimbus-eth2/pull/1084