### PR TITLE
Run fuzzing test during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,41 @@ jobs:
         run: echo '${{ github.workspace }}/nim/bin' >> $GITHUB_PATH
 
 
+      - name: Install fuzzing engines (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+
+          # libFuzzer
+          sudo apt-get install -y clang
+
+          # honggfuzz
+          nimble install -y testutils
+          "$(nimble path testutils | head -1)/scripts/install_honggfuzz.sh"
+          echo "/opt/honggfuzz/usr/local/bin" >> "$GITHUB_PATH"
+
+          # afl
+          sudo apt-get install -y afl++
+          sudo afl-system-config
+
+      - name: Install fuzzing engines (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+
+          # libFuzzer
+          brew install llvm
+          echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
+
+          # honggfuzz
+          nimble install -y testutils
+          "$(nimble path testutils | head -1)/scripts/install_honggfuzz.sh"
+          echo "/opt/honggfuzz/usr/local/bin" >> "$GITHUB_PATH"
+
+          # afl
+          brew install afl++
+          sudo afl-system-config
+
 
       - name: Run tests (hashtree_abi via vendor directory import)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,9 @@ jobs:
           key: nim-${{ matrix.branch }}-${{ steps.nim-hash.outputs.nim_commit_hash }}-${{ matrix.target.os }}-${{ matrix.target.cpu }}
 
       - name: Add Nim bin to GITHUB_PATH
-        run: echo '${{ github.workspace }}/nim/bin' >> $GITHUB_PATH
+        run: |
+          echo '${{ github.workspace }}/nim/bin' >> "$GITHUB_PATH"
+          echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
 
 
       - name: Install fuzzing engines (Linux)

--- a/ssz_serialization.nimble
+++ b/ssz_serialization.nimble
@@ -44,7 +44,20 @@ task test, "Run all tests":
       let opts = "--threads:on -d:PREFER_BLST_SHA256=" & $blst & " -d:PREFER_HASHTREE_SHA256=" & $hashtree
       run opts, "tests/test_all"
 
+let
+  fuzzSeconds = getEnv("FUZZ_SECONDS", "100")
+  fuzzTime =
+    if fuzzSeconds == "": ""
+    else: " --duration=" & fuzzSeconds & " "
+
+proc fuzz(format: string) =
+  for fuzzer in ["libFuzzer", "honggfuzz", "afl"]:
+    when defined(macosx):
+      if fuzzer == "honggfuzz":
+        continue
+
+    exec "ntu fuzz --fuzzer=" & fuzzer & fuzzTime &
+      "tests/fuzzing/fuzz_" & format
+
 task fuzzHashtree, "Run fuzzing test":
-  # TODO We don't run because the timeout parameter doesn't seem to work so
-  # this takes too long
-  build "-d:release", "tests/fuzzing/fuzz_hashtree"
+  fuzz("hashtree")

--- a/ssz_serialization.nimble
+++ b/ssz_serialization.nimble
@@ -16,6 +16,7 @@ requires "nim >= 2.0.10",
          "blscurve",
          "results",
          "unittest2",
+         "testutils",
          "hashtree_abi"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/tests/fuzzing/fuzz_hashtree.nim
+++ b/tests/fuzzing/fuzz_hashtree.nim
@@ -1,6 +1,6 @@
 import system/ansi_c, stew/[importops, ptrops], blscurve
 
-when not tryImport ../vendor/hashtree/hashtree_abi:
+when not tryImport ../../vendor/hashtree/hashtree_abi:
   import hashtree_abi
 
 proc testOneInput(


### PR DESCRIPTION
There is a fuzzing test that was added in #35 but we only compile it but don't run it. Now that nim-testutils has been updated to support fuzz, add this test to CI.