### PR TITLE
Allow skipping cache reset in 'fill' convenience wrapper

### DIFF
--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -808,10 +808,12 @@ template clear*(a: var HashList) =
 template clear*(a: var HashSeq) =
   a.reset()
 
-template fill*(a: var HashArray, c: auto) =
+template fill*(
+    a: var HashArray, c: auto, skipCacheReset: static[bool] = false) =
   mixin fill
   fill(a.data, c)
-  a.resetCache()
+  when not skipCacheReset:
+    a.resetCache()
 
 template sum*[maxLen; T](a: var HashArray[maxLen, T]): T =
   mixin sum


### PR DESCRIPTION
Rather than have the caller 'fill' the internal buffer directly, expose this option via a static bool flag for the situation where caller knows that they have a fresh instance.