### PR TITLE
Extend cache tests: Ensure cached matches uncached

### DIFF
--- a/tests/test_hashcache.nim
+++ b/tests/test_hashcache.nim
@@ -19,7 +19,7 @@ type Foo = object
   x: Digest
   y: uint64
 
-let foo = Foo(
+const foo = Foo(
   x: Digest(data: array[32, byte].fromHex(
     "0x4175371111cef0d13cb836c17dba708f026f2ddbf057b91384bb78b1ba42343c")),
   y: 42)
@@ -236,3 +236,143 @@ suite "HashArray":
   runHashArrayTests(127)
   runHashArrayTests(128)
   runHashArrayTests(129)
+
+type Bar = object
+  x: HashArray[9, uint64]
+  y: uint64
+
+when (NimMajor, NimMinor) < (2, 2):
+  template newSeqUninit[T](len: Natural): seq[T] =
+    newSeq[T](len)
+
+suite "Multiproof cache":
+  func init(T: typedesc[Foo], i: int): T =
+    T(x: foo.x, y: (i + 1).uint64)
+
+  func init(T: typedesc[Bar], i: int): T =
+    var res: T
+    for k in 0 ..< 9:
+      res.x[k] = (i * 10 + k).uint64
+    res.y = i.uint64
+    res
+
+  template runCachedTest(
+      initObj: proc, maxGindex: GeneralizedIndex): untyped =
+    let obj = initObj()
+    test "Cached matches uncached result - " & $typeof(obj) & " - " & $obj.len:
+      let
+        allGindices = (1.GeneralizedIndex .. maxGindex).mapIt(it)
+        validGindices = allGindices.filterIt(obj.hash_tree_root(it).isOk)
+
+      var tests = @[allGindices]
+      for i in 1 .. maxGindex:
+        tests.add @[i.GeneralizedIndex]
+
+      randomize()
+      const numRandomTests = 100
+      for _ in 0 ..< numRandomTests:
+        var indices: seq[GeneralizedIndex]
+        for i in (if rand(1.0) < 0.8: validGindices else: allGindices):
+          if rand(1.0) < 0.35:
+            indices.add i
+        indices.shuffle()
+        tests.add indices
+
+      for indices in tests:
+        var
+          uncached = initObj()
+          uncachedRoots = newSeqUninit[Digest](indices.len)
+          uncachedTopRoot: Digest
+        let res1 =
+          hash_tree_root(uncached, indices, uncachedRoots, uncachedTopRoot)
+
+        var
+          cached = initObj()
+          cachedRoots = newSeqUninit[Digest](indices.len)
+          cachedTopRoot: Digest
+        let
+          root = cached.hash_tree_root()
+          res2 = hash_tree_root(cached, indices, cachedRoots, cachedTopRoot)
+
+        checkpoint $indices
+        check:
+          hash_tree_root(uncached) == root
+          hash_tree_root(cached) == root
+          res1.isOk == res2.isOk
+        if res1.isOk:
+          check:
+            uncachedRoots == cachedRoots
+            uncachedTopRoot == cachedTopRoot
+            uncachedTopRoot == root
+          for o, i in indices:
+            if i == 1.GeneralizedIndex:
+              check uncachedRoots[o] == root
+
+  block:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< T.maxLen:
+        res[i] = (i + 1).uint64
+      res
+
+    initObj[HashArray[8, uint64]].runCachedTest(7.GeneralizedIndex)
+    initObj[HashArray[9, uint64]].runCachedTest(15.GeneralizedIndex)
+    initObj[HashArray[17, uint64]].runCachedTest(31.GeneralizedIndex)
+
+  block:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< T.maxLen:
+        res[i] = Foo.init(i)
+      res
+
+    initObj[HashArray[3, Foo]].runCachedTest(31.GeneralizedIndex)
+    initObj[HashArray[4, Foo]].runCachedTest(63.GeneralizedIndex)
+    initObj[HashArray[6, Foo]].runCachedTest(63.GeneralizedIndex)
+
+  block:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< T.maxLen:
+        res[i] = Bar.init(i)
+      res
+
+    initObj[HashArray[3, Bar]].runCachedTest(127.GeneralizedIndex)
+    initObj[HashArray[4, Bar]].runCachedTest(127.GeneralizedIndex)
+    initObj[HashArray[6, Bar]].runCachedTest(127.GeneralizedIndex)
+
+  for n in [0, 1, 2, 3, 4, 5, 7, 8, 9, 16, 31, 32]:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< n:
+        doAssert res.add((i + 1).uint64)
+      res
+
+    initObj[HashList[uint64, 32]].runCachedTest(63.GeneralizedIndex)
+
+  for n in [0, 1, 2, 3, 5, 8, 13, 16]:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< n:
+        doAssert res.add(Foo.init(i))
+      res
+
+    initObj[HashList[Foo, 16]].runCachedTest(127.GeneralizedIndex)
+
+  for n in [0, 1, 2, 4, 5, 6, 7, 20, 21, 22, 84, 85, 86, 340, 341]:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< n:
+        doAssert res.add((i + 1).uint64)
+      res
+
+    initObj[HashSeq[uint64]].runCachedTest(1023.GeneralizedIndex)
+
+  for n in [1, 5, 6, 21, 22]:
+    func initObj[T]: T {.closure.} =
+      var res: T
+      for i in 0 ..< n:
+        doAssert res.add(Foo.init(i))
+      res
+
+    initObj[HashSeq[Foo]].runCachedTest(1023.GeneralizedIndex)

--- a/tests/test_merkleization_types.nim
+++ b/tests/test_merkleization_types.nim
@@ -2065,6 +2065,7 @@ suite "Merkleization types":
       @[0b101111010110100000010000100100.GeneralizedIndex, 0b110001001,
         0b1100000101, 0b1100000101001, 0b110000, 0b101110100100101,
         0b101111010110011],
+      @[0b100110000.GeneralizedIndex, 0b1001100001],
     ]
     for i in tests:
       checkpoint $i.mapIt(toBin(it.int64))


### PR DESCRIPTION
As there have been a couple of gaps with the cache, makes sense to add more tests for cache handling. Verify that a fresh instance produces the same output as a fully cached instance, for various access patterns.