### PR TITLE
Reduce multiproof hash count when requesting padding chunks

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -215,10 +215,12 @@ func combineToTop(merkleizer: var SszMerkleizer2, res: var Digest) =
           trs "COMBINED"
           mergeBranches(
             merkleizer.combinedChunks[i][0], merkleizer.combinedChunks[i][1],
-            res)
+            merkleizer.combinedChunks[topHashIdx][0])
         else:
           trs "COMBINED WITH ZERO"
-          mergeBranches(merkleizer.combinedChunks[i][1], zeroHashes[i], res)
+          mergeBranches(
+            merkleizer.combinedChunks[i][1], zeroHashes[i],
+            merkleizer.combinedChunks[topHashIdx][0])
       else:
         if getBitLE(merkleizer.totalChunks, i):
           trs "COMBINED"
@@ -231,16 +233,15 @@ func combineToTop(merkleizer: var SszMerkleizer2, res: var Digest) =
             merkleizer.combinedChunks[i][1], zeroHashes[i],
             merkleizer.combinedChunks[i + 1][1])
 
-  elif bottomHashIdx == topHashIdx:
-    # We have a perfect tree (chunks == 2**n) at just the right height!
-    assign(res, merkleizer.combinedChunks[bottomHashIdx][0])
-  else:
+    merkleizer.totalChunks = 1'u64 shl topHashIdx
+  elif bottomHashIdx != topHashIdx:
     # We have a perfect tree of user chunks, but we have more work to
     # do - we must extend it to reach the desired height
     if bottomHashIdx == topHashIdx - 1:
       mergeBranches(
         merkleizer.combinedChunks[topHashIdx - 1][0],
-        zeroHashes[topHashIdx - 1], res)
+        zeroHashes[topHashIdx - 1],
+        merkleizer.combinedChunks[topHashIdx][0])
     else:
       mergeBranches(
         merkleizer.combinedChunks[bottomHashIdx][0],
@@ -254,7 +255,15 @@ func combineToTop(merkleizer: var SszMerkleizer2, res: var Digest) =
 
       mergeBranches(
         merkleizer.combinedChunks[topHashIdx - 1][1],
-        zeroHashes[topHashIdx - 1], res)
+        zeroHashes[topHashIdx - 1],
+        merkleizer.combinedChunks[topHashIdx][0])
+
+    merkleizer.totalChunks = 1'u64 shl topHashIdx
+  else:
+    # We have a perfect tree (chunks == 2**n) at just the right height!
+    doAssert merkleizer.totalChunks == 1'u64 shl topHashIdx
+
+  assign(res, merkleizer.combinedChunks[topHashIdx][0])
 
 func combineChunks(merkleizer: var SszMerkleizer2, start: int) =
   for i in start..<merkleizer.topIndex:
@@ -1169,7 +1178,8 @@ func fulfill(
         chunk = chunks.a
         allFulfilled = false
 
-      template addChunksUpThrough(highChunk: Limit) =
+      template addChunksUpThrough(maxChunk: Limit) =
+        let highChunk = min(maxChunk, totalChunkCount - 1)
         while chunk <= highChunk:
           merkleizer.addChunkDirect:
             chunk.getTopRoot(depth, outChunk)
@@ -1187,8 +1197,11 @@ func fulfill(
           if shouldSkip(i):
             inc i
             continue
-          let lastUsedSubChunk = min(subChunks.b, totalChunkCount - 1)
-          addChunksUpThrough(lastUsedSubChunk)
+          if subChunks.a >= totalChunkCount:
+            assign(rootAt(i), zeroHashes[chunkLayer - indexLayer])
+            inc i
+            continue
+          addChunksUpThrough(subChunks.b)
           if chunk == totalChunkCount:
             break
           let layerIdx = chunkLayer - indexLayer
@@ -1210,9 +1223,8 @@ func fulfill(
             assign(outChunk, batch.topRoot)
           inc chunk
       if not allFulfilled or needTopRoot:
-        addChunksUpThrough(min(chunks.b, totalChunkCount - 1))
-        merkleizer.combineToTop(
-          merkleizer.combinedChunks[merkleizer.topIndex][1])
+        addChunksUpThrough(chunks.b)
+        let totalChunks = merkleizer.totalChunks
         while i <= batch.loopOrderHigh:
           let (stem, index, indexLayer) = indexAt(i)
           if shouldStop:
@@ -1227,14 +1239,17 @@ func fulfill(
             let layerIdx = chunkLayer - indexLayer
             if subChunks.a >= totalChunkCount:
               assign(rootAt(i), zeroHashes[layerIdx])
-            elif subChunks.b < merkleizer.totalChunks.Limit or
-                layerIdx <= firstOne(max(merkleizer.totalChunks, 1)) - 1:
-              if getBitLE(merkleizer.totalChunks, layerIdx):
-                assign(rootAt(i), merkleizer.combinedChunks[layerIdx][0])
+            else:
+              merkleizer.combineToTop(
+                merkleizer.combinedChunks[merkleizer.topIndex][1])
+              if subChunks.b < totalChunks.Limit or
+                  layerIdx <= firstOne(max(totalChunks, 1)) - 1:
+                if getBitLE(totalChunks, layerIdx):
+                  assign(rootAt(i), merkleizer.combinedChunks[layerIdx][0])
+                else:
+                  assign(rootAt(i), merkleizer.combinedChunks[layerIdx][1])
               else:
                 assign(rootAt(i), merkleizer.combinedChunks[layerIdx][1])
-            else:
-              assign(rootAt(i), merkleizer.combinedChunks[layerIdx][1])
             inc i
           else:
             let subChunk = chunkForIndex(index shr (indexLayer - chunkLayer))
@@ -1242,8 +1257,7 @@ func fulfill(
               break
             return err()
         if needTopRoot:
-          assign(
-            batch.topRoot, merkleizer.combinedChunks[merkleizer.topIndex][1])
+          merkleizer.combineToTop(batch.topRoot)
     elif indexLayer == chunkLayer:
       while i <= batch.loopOrderHigh:
         let (stem, index, indexLayer) = indexAt(i)

--- a/tests/test_merkleization_types.nim
+++ b/tests/test_merkleization_types.nim
@@ -2106,6 +2106,95 @@ suite "Merkleization types":
         roots == r
         hash_tree_root(x, i).get == roots
 
+  test "Multiproof (padding)":
+    let
+      x = List[uint64, 4096].init toSeq(0'u64 ..< 100'u64)
+      i = [5.GeneralizedIndex, 10, 11, 44, 45]
+    var roots {.noinit.}: array[i.len, Digest]
+    when SSZ_DEBUG_COUNT_HASHES:
+      let numHashesBefore = debugTotalSszHashes
+    check:
+      hash_tree_root(x, i, roots).isOk
+      roots == [
+        #[5]# zeroHashes[9],
+        #[10]# zeroHashes[8], #[11]# zeroHashes[8],
+        #[44]# zeroHashes[6], #[45]# zeroHashes[6]]
+    when SSZ_DEBUG_COUNT_HASHES:
+      check debugTotalSszHashes == numHashesBefore
+
+  test "Multiproof (boundary at data end)":
+    let
+      x = List[uint64, 4096].init toSeq(0'u64 ..< 100'u64)
+      i = [8.GeneralizedIndex, 16]
+    var roots {.noinit.}: array[i.len, Digest]
+    check:
+      hash_tree_root(x, i, roots).isOk
+      roots == [
+        #[8]# (block:
+          var res: array[1024, uint64]
+          for i in 0'u64 ..< 100'u64:
+            res[i] = i
+          res).hash_tree_root(),
+        #[16]# (block:
+          var res: array[512, uint64]
+          for i in 0'u64 ..< 100'u64:
+            res[i] = i
+          res).hash_tree_root()]
+    when SSZ_DEBUG_COUNT_HASHES:
+      let numHashesBefore = debugTotalSszHashes
+      check hash_tree_root(x, 8.GeneralizedIndex).isOk
+      let numItemHashes = debugTotalSszHashes - numHashesBefore
+      check:
+        hash_tree_root(x, 16.GeneralizedIndex).isOk
+        debugTotalSszHashes == numHashesBefore + 2 * numItemHashes - 1
+
+  test "Multiproof (overlapped item root)":
+    type
+      Inner = object
+        a, b, c, d: uint64
+      Outer = object
+        x: Inner
+        y: uint64
+    var x: array[8, Outer]
+    for i in 0'u64 ..< 8'u64:
+      x[i].x.a = 100 + i
+      x[i].x.b = 200 + i
+      x[i].x.c = 300 + i
+      x[i].x.d = 400 + i
+      x[i].y = 500 + i
+    let tests =[
+      @[9.GeneralizedIndex, 18],
+      @[9.GeneralizedIndex, 72],
+      @[2.GeneralizedIndex, 9, 18],
+      @[2.GeneralizedIndex, 9, 18, 19],
+    ]
+    for i in tests:
+      checkpoint $i
+      var roots =
+        when (NimMajor, NimMinor) < (2, 2):
+          newSeq[Digest](i.len)
+        else:
+          newSeqUninit[Digest](i.len)
+      for x in roots.mitems:
+        x.data[0] = 0xba
+        x.data[1] = 0xad
+      check hash_tree_root(x, i, roots).isOk
+      for j, i in i:
+        let r =
+          case i
+          of 2.GeneralizedIndex:
+            hash_tree_root([x[0], x[1], x[2], x[3]])
+          of 9.GeneralizedIndex:
+            hash_tree_root(x[1])
+          of 18.GeneralizedIndex:
+            hash_tree_root(x[1].x)
+          of 19.GeneralizedIndex:
+            hash_tree_root(x[1].y)
+          else:
+            doAssert i == 72.GeneralizedIndex
+            hash_tree_root(x[1].x.a)
+        check roots[j] == r
+
 type
   InnerA = object
     a: uint64


### PR DESCRIPTION
Use the zero hash optimization for early returns in more scenarios where part of the padding is requested, and also optimize case when an item's root is requested together with nested data (i.e. proof union).

There's a tiny bit more memcpy in the combineToTop, where it now always initializes merkleizer.combinedChunks[topHashIdx][0] for later reuse. It's cleaner than trying to track whether combine has already been called, or inferring it from totalChunk properties...