### PR TITLE
Hardening against multiproofs with wrong length

### DIFF
--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -257,17 +257,24 @@ func calculate_multi_merkle_root*(
     return err("Length mismatch for leaves and indices")
   ? check_multiproof_acceptable(indices)
   let helper_indices = get_helper_indices(indices)
+  if proof.len != helper_indices.len:
+    return err("Length mismatch for proof and helper indices")
   calculate_multi_merkle_root_impl(leaves, proof, indices, helper_indices)
 
 func calculate_multi_merkle_root*(
     leaves: openArray[Digest],
     proof: openArray[Digest],
     indices: static openArray[GeneralizedIndex]): Result[Digest, string] =
-  if leaves.len != indices.len:
-    return err("Length mismatch for leaves and indices")
-  static: ? check_multiproof_acceptable(indices)
-  const helper_indices = get_helper_indices(indices)
-  calculate_multi_merkle_root_impl(leaves, proof, indices, helper_indices)
+  const v = check_multiproof_acceptable(indices)
+  when v.isErr:
+    result.err(v.error)
+  else:
+    if leaves.len != indices.len:
+      return err("Length mismatch for leaves and indices")
+    const helper_indices = get_helper_indices(indices)
+    if proof.len != helper_indices.len:
+      return err("Length mismatch for proof and helper indices")
+    calculate_multi_merkle_root_impl(leaves, proof, indices, helper_indices)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/ssz/merkle-proofs.md#merkle-multiproofs
 func verify_merkle_multiproof*(
@@ -277,7 +284,8 @@ func verify_merkle_multiproof*(
     helper_indices: openArray[GeneralizedIndex],
     root: Digest): bool =
   let calc = calculate_multi_merkle_root(leaves, proof, indices, helper_indices)
-  if calc.isErr: return false
+  if calc.isErr:
+    return false
   calc.get == root
 
 func verify_merkle_multiproof*(
@@ -286,7 +294,8 @@ func verify_merkle_multiproof*(
     indices: openArray[GeneralizedIndex],
     root: Digest): bool =
   let calc = calculate_multi_merkle_root(leaves, proof, indices)
-  if calc.isErr: return false
+  if calc.isErr:
+    return false
   calc.get == root
 
 func verify_merkle_multiproof*(
@@ -294,9 +303,9 @@ func verify_merkle_multiproof*(
     proof: openArray[Digest],
     indices: static openArray[GeneralizedIndex],
     root: Digest): bool =
-  const helper_indices = get_helper_indices(indices)
-  let calc = calculate_multi_merkle_root(leaves, proof, indices, helper_indices)
-  if calc.isErr: return false
+  let calc = calculate_multi_merkle_root(leaves, proof, indices)
+  if calc.isErr:
+    return false
   calc.get == root
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/tests/core/pyspec/eth_consensus_specs/test/helpers/merkle.py#L4-L21

--- a/tests/test_proofs.nim
+++ b/tests/test_proofs.nim
@@ -118,8 +118,8 @@ suite "Merkle proofs":
 
     var nodes: array[16, Digest]
     for i in 0 ..< allLeaves.len:
-      nodes[i + 8] = allLeaves[i]
-    for i in countdown(7, 1):
+      nodes[i + allLeaves.len] = allLeaves[i]
+    for i in countdown(allLeaves.high, 1):
       nodes[i] = digest(nodes[2 * i + 0].data, nodes[2 * i + 1].data)
 
     staticFor index_int, 1 .. 15:
@@ -194,6 +194,24 @@ suite "Merkle proofs":
     staticFor index_int, 8 .. 15:
       const index = index_int.GeneralizedIndex
       all_roots.verifyBranch(all_union, index)
+
+    template verifyReject(proof: openArray[Digest], indices: typed) =
+      check:
+        calculate_multi_merkle_root(leaves, proof, indices).isErr
+        not verify_merkle_multiproof(leaves, proof, indices, root)
+
+    const static_indices = [12.GeneralizedIndex, 10, 6]
+    let
+      indices = [12.GeneralizedIndex, 10, 6]
+      helper_indices = get_helper_indices(indices)
+      leaves = indices.mapIt(nodes[it])
+      proof = helper_indices.mapIt(nodes[it])
+      root = nodes[1]
+    verifyReject(proof[0 ..< ^1], indices)
+    verifyReject(proof[0 ..< ^1], static_indices)
+    verifyReject(proof & @[default(Digest)], indices)
+    verifyReject(proof & @[default(Digest)], static_indices)
+    verifyReject(proof, [0.GeneralizedIndex])
 
   test "is_valid_merkle_branch":
     type TestCase = object


### PR DESCRIPTION
When client doesn't compute helpers themselves, it can be a bit tricky to validate correct proof length. Do that check as part of the library for the convenience wrappers that don't take client's helper_indices.