### PR TITLE
Overloads for build_proof that also return the top root

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -2610,7 +2610,7 @@ func hash_tree_root*(
     let loopOrder = merkleizationLoopOrder(indices)
     ? validateIndices(indices, loopOrder)
     var
-      roots = newSeq[Digest](indices.len)
+      roots = newSeqUninit[Digest](indices.len)
       batch = BatchRequest.init(indices, roots, loopOrder)
     let numFulfilled = hash_tree_root_multi(x, addr batch).valueOr:
       return err(unsupportedIndex)

--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -310,11 +310,31 @@ func build_proof*(
 func build_proof*(
     anchor: auto,
     indices: openArray[GeneralizedIndex],
+    helper_indices: openArray[GeneralizedIndex],
+    proof: var openArray[Digest],
+    topRoot: var Digest): Result[void, string] =
+  doAssert proof.len == helper_indices.len
+  ? check_multiproof_acceptable(indices)
+  hash_tree_root(anchor, helper_indices, proof, topRoot)
+
+func build_proof*(
+    anchor: auto,
+    indices: openArray[GeneralizedIndex],
     proof: var openArray[Digest]): Result[void, string] =
   ? check_multiproof_acceptable(indices)
   let helper_indices = get_helper_indices(indices)
   doAssert proof.len == helper_indices.len
   hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    indices: openArray[GeneralizedIndex],
+    proof: var openArray[Digest],
+    topRoot: var Digest): Result[void, string] =
+  ? check_multiproof_acceptable(indices)
+  let helper_indices = get_helper_indices(indices)
+  doAssert proof.len == helper_indices.len
+  hash_tree_root(anchor, helper_indices, proof, topRoot)
 
 func build_proof*(
     anchor: auto,
@@ -330,12 +350,35 @@ func build_proof*(
 
 func build_proof*(
     anchor: auto,
+    indices: static openArray[GeneralizedIndex],
+    proof: var openArray[Digest],
+    topRoot: var Digest): Result[void, string] =
+  const v = check_multiproof_acceptable(indices)
+  when v.isErr:
+    result.err(v.error)
+  else:
+    const helper_indices = get_helper_indices(indices)
+    doAssert proof.len == helper_indices.len
+    hash_tree_root(anchor, helper_indices, proof, topRoot)
+
+func build_proof*(
+    anchor: auto,
     index: GeneralizedIndex,
     proof: var openArray[Digest]): Result[void, string] =
   ? check_multiproof_acceptable(index)
   let helper_indices = get_helper_indices(index)
   doAssert proof.len == helper_indices.len
   hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    index: GeneralizedIndex,
+    proof: var openArray[Digest],
+    topRoot: var Digest): Result[void, string] =
+  ? check_multiproof_acceptable(index)
+  let helper_indices = get_helper_indices(index)
+  doAssert proof.len == helper_indices.len
+  hash_tree_root(anchor, helper_indices, proof, topRoot)
 
 func build_proof*(
     anchor: auto,
@@ -348,6 +391,19 @@ func build_proof*(
     const helper_indices = get_helper_indices(index)
     doAssert proof.len == helper_indices.len
     hash_tree_root(anchor, helper_indices, proof)
+
+func build_proof*(
+    anchor: auto,
+    index: static GeneralizedIndex,
+    proof: var openArray[Digest],
+    topRoot: var Digest): Result[void, string] =
+  const v = check_multiproof_acceptable(index)
+  when v.isErr:
+    result.err(v.error)
+  else:
+    const helper_indices = get_helper_indices(index)
+    doAssert proof.len == helper_indices.len
+    hash_tree_root(anchor, helper_indices, proof, topRoot)
 
 func build_proof*(
     anchor: auto,

--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -415,6 +415,17 @@ func build_proof*(
 
 func build_proof*(
     anchor: auto,
+    indices: openArray[GeneralizedIndex],
+    topRoot: var Digest
+): Result[seq[Digest], string] =
+  ? check_multiproof_acceptable(indices)
+  let helper_indices = get_helper_indices(indices)
+  var roots = newSeqUninit[Digest](helper_indices.len)
+  ? hash_tree_root(anchor, helper_indices, roots, topRoot)
+  ok roots
+
+func build_proof*(
+    anchor: auto,
     indices: static openArray[GeneralizedIndex]
 ): auto =
   const v = check_multiproof_acceptable(indices)
@@ -426,11 +437,38 @@ func build_proof*(
 
 func build_proof*(
     anchor: auto,
+    indices: static openArray[GeneralizedIndex],
+    topRoot: var Digest
+): auto =
+  const v = check_multiproof_acceptable(indices)
+  when v.isErr:
+    Result[array[0, Digest], string].err(v.error)
+  else:
+    const helper_indices = get_helper_indices(indices)
+    type ResultType = Result[array[helper_indices.len, Digest], string]
+    var roots {.noinit.}: array[helper_indices.len, Digest]
+    hash_tree_root(anchor, helper_indices, roots, topRoot).isOkOr:
+      return ResultType.err error
+    ResultType.ok roots
+
+func build_proof*(
+    anchor: auto,
     index: GeneralizedIndex
 ): Result[seq[Digest], string] =
   ? check_multiproof_acceptable(index)
   let helper_indices = get_helper_indices(index)
   hash_tree_root(anchor, helper_indices)
+
+func build_proof*(
+    anchor: auto,
+    index: GeneralizedIndex,
+    topRoot: var Digest
+): Result[seq[Digest], string] =
+  ? check_multiproof_acceptable(index)
+  let helper_indices = get_helper_indices(index)
+  var roots = newSeqUninit[Digest](helper_indices.len)
+  ? hash_tree_root(anchor, helper_indices, roots, topRoot)
+  ok roots
 
 func build_proof*(
     anchor: auto,
@@ -442,6 +480,22 @@ func build_proof*(
   else:
     const helper_indices = get_helper_indices(index)
     hash_tree_root(anchor, helper_indices)
+
+func build_proof*(
+    anchor: auto,
+    index: static GeneralizedIndex,
+    topRoot: var Digest
+): auto =
+  const v = check_multiproof_acceptable(index)
+  when v.isErr:
+    Result[array[0, Digest], string].err(v.error)
+  else:
+    const helper_indices = get_helper_indices(index)
+    type ResultType = Result[array[helper_indices.len, Digest], string]
+    var roots {.noinit.}: array[helper_indices.len, Digest]
+    hash_tree_root(anchor, helper_indices, roots, topRoot).isOkOr:
+      return ResultType.err error
+    ResultType.ok roots
 
 func extract_branch*(
     roots: openArray[Digest],
@@ -465,7 +519,7 @@ func extract_branch*(
     roots: openArray[Digest],
     union_indices: openArray[GeneralizedIndex],
     indices: openArray[GeneralizedIndex]): Result[seq[Digest], string] =
-  var branch = newSeq[Digest](indices.len)
+  var branch = newSeqUninit[Digest](indices.len)
   ? roots.extract_branch(union_indices, indices, branch)
   ok branch
 

--- a/tests/test_proofs.nim
+++ b/tests/test_proofs.nim
@@ -136,6 +136,7 @@ suite "Merkle proofs":
         nodes[index_int] == foo.hash_tree_root(index).get
         nodes[index_int] == allLeaves.hash_tree_root(index).get
 
+    var checkKind = 0
     proc verify(indices_int: openArray[int]) =
       let
         indices = indices_int.mapIt(it.GeneralizedIndex)
@@ -144,10 +145,31 @@ suite "Merkle proofs":
         proof = helper_indices.mapIt(nodes[it])
         root = nodes[1]
       checkpoint "Verifying " & $indices & "---" & $helper_indices
-      check:
-        proof == foo.build_proof(indices).get
-        proof == allLeaves.build_proof(indices).get
-        verify_merkle_multiproof(leaves, proof, indices, root)
+
+      template doVerify(anchor: auto) =
+        case checkKind
+        of 0:
+          check proof == anchor.build_proof(indices).get
+        of 1:
+          var proof2 = newSeqUninit[Digest](proof.len)
+          check:
+            anchor.build_proof(indices, proof2).isOk
+            proof2 == proof
+        of 2:
+          var
+            proof2 = newSeqUninit[Digest](proof.len)
+            top_root: Digest
+          check:
+            anchor.build_proof(indices, proof2, top_root).isOk
+            proof2 == proof
+            top_root == root
+        else:
+          discard
+        checkKind = (checkKind + 1) mod 3
+
+      foo.doVerify()
+      allLeaves.doVerify()
+      check verify_merkle_multiproof(leaves, proof, indices, root)
 
     verify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 
@@ -167,9 +189,18 @@ suite "Merkle proofs":
         union_indices: openArray[GeneralizedIndex],
         index: static GeneralizedIndex) =
       let branch = union_roots.extract_branch(union_indices, index)
+      var
+        proof1 = newSeqUninit[Digest](branch.get.len)
+        proof2 = newSeqUninit[Digest](branch.get.len)
+        top_root: Digest
       check:
         branch.isOk
         branch.get == foo.build_proof(index).get
+        foo.build_proof(index, proof1).isOk
+        foo.build_proof(index, proof2, top_root).isOk
+        branch.get == proof1
+        branch.get == proof2
+        top_root == nodes[1]
         is_valid_merkle_branch(
           nodes[index], branch.get, log2trunc(index),
           get_subtree_index(index), nodes[1])

--- a/tests/test_proofs.nim
+++ b/tests/test_proofs.nim
@@ -151,11 +151,16 @@ suite "Merkle proofs":
         of 0:
           check proof == anchor.build_proof(indices).get
         of 1:
+          var top_root: Digest
+          check:
+            proof == anchor.build_proof(indices, topRoot).get
+            top_root == root
+        of 2:
           var proof2 = newSeqUninit[Digest](proof.len)
           check:
             anchor.build_proof(indices, proof2).isOk
             proof2 == proof
-        of 2:
+        of 3:
           var
             proof2 = newSeqUninit[Digest](proof.len)
             top_root: Digest
@@ -165,7 +170,7 @@ suite "Merkle proofs":
             top_root == root
         else:
           discard
-        checkKind = (checkKind + 1) mod 3
+        checkKind = (checkKind + 1) mod 4
 
       foo.doVerify()
       allLeaves.doVerify()
@@ -192,15 +197,18 @@ suite "Merkle proofs":
       var
         proof1 = newSeqUninit[Digest](branch.get.len)
         proof2 = newSeqUninit[Digest](branch.get.len)
-        top_root: Digest
+        top_root1: Digest
+        top_root2: Digest
       check:
         branch.isOk
         branch.get == foo.build_proof(index).get
+        branch.get == foo.build_proof(index, top_root1).get
         foo.build_proof(index, proof1).isOk
-        foo.build_proof(index, proof2, top_root).isOk
+        foo.build_proof(index, proof2, top_root2).isOk
         branch.get == proof1
         branch.get == proof2
-        top_root == nodes[1]
+        top_root1 == nodes[1]
+        top_root2 == nodes[1]
         is_valid_merkle_branch(
           nodes[index], branch.get, log2trunc(index),
           get_subtree_index(index), nodes[1])


### PR DESCRIPTION
Can sometimes be useful to obtain both a proof as well as the top hash_tree_root in the same pass, to avoid repeated hash computation.