### PR TITLE
Drop Nim 2.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             cpu: amd64
             platform: x64
             builder: windows-latest
-        branch: [version-2-0, version-2-2, version-2-4, devel]
+        branch: [version-2-2, version-2-4, devel]
 
     defaults:
       run:

--- a/ssz_serialization.nimble
+++ b/ssz_serialization.nimble
@@ -7,7 +7,7 @@ description   = "Simple Serialize (SSZ) serialization and merkleization"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 2.0.10",
+requires "nim >= 2.2.10",
          "serialization >= 0.5.0",
          "json_serialization",
          "stew >= 0.4.2",

--- a/ssz_serialization.nimble
+++ b/ssz_serialization.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "ssz_serialization"
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Status Research & Development GmbH"
 description   = "Simple Serialize (SSZ) serialization and merkleization"
 license       = "Apache License 2.0"

--- a/ssz_serialization/codec.nim
+++ b/ssz_serialization/codec.nim
@@ -48,10 +48,7 @@ func setOutputSize[T](x: var seq[T], length: int) {.raises: [SszError].} =
   # We will overwrite all bytes
   when T is SomeNumber:
     if x.len != length:
-      when (NimMajor, NimMinor) < (2, 2):
-        x = newSeqUninitialized[T](length)
-      else:
-        x = newSeqUninit[T](length)
+      x = newSeqUninit[T](length)
   else:
     x.setLen(length)
 

--- a/ssz_serialization/types.nim
+++ b/ssz_serialization/types.nim
@@ -337,11 +337,8 @@ func setLenUninitialized*(x: var List, newLen: int): bool =
   if newLen <= x.maxLen:
     # TODO https://github.com/nim-lang/Nim/issues/19727
     when List.T is SomeNumber:
-      if x.len !=  newLen:
-        distinctBase(x) = when (NimMajor, NimMinor) < (2, 2):
-                            newSeqUninitialized[x.T](newLen)
-                          else:
-                            newSeqUninit[x.T](newLen)
+      if x.len != newLen:
+        distinctBase(x) = newSeqUninit[x.T](newLen)
     else:
       setLen(distinctBase(x), newLen)
     true

--- a/tests/test_hashcache.nim
+++ b/tests/test_hashcache.nim
@@ -243,10 +243,6 @@ type Bar = object
   x: HashArray[BarXMaxLen, uint64]
   y: uint64
 
-when (NimMajor, NimMinor) < (2, 2):
-  template newSeqUninit[T](len: Natural): seq[T] =
-    newSeq[T](len)
-
 suite "Multiproof cache":
   func init(T: typedesc[Foo], i: int): T =
     T(x: foo.x, y: (i + 1).uint64)

--- a/tests/test_merkleization_types.nim
+++ b/tests/test_merkleization_types.nim
@@ -1989,11 +1989,7 @@ suite "Merkleization types":
       let helpers = get_helper_indices(indices)
       checkpoint $helpers.mapIt(toBin(it.int64))
       let r = helpers.mapIt(roots.getOrDefault(it.int64))
-      var roots =
-        when (NimMajor, NimMinor) < (2, 2):
-          newSeq[Digest](helpers.len)
-        else:
-          newSeqUninit[Digest](helpers.len)
+      var roots = newSeqUninit[Digest](helpers.len)
       hash_tree_root(x, helpers, roots).get
       check:
         roots == r
@@ -2070,11 +2066,7 @@ suite "Merkleization types":
     for i in tests:
       checkpoint $i.mapIt(toBin(it.int64))
       let r = i.mapIt(roots.getOrDefault(it.int64))
-      var roots =
-        when (NimMajor, NimMinor) < (2, 2):
-          newSeq[Digest](i.len)
-        else:
-          newSeqUninit[Digest](i.len)
+      var roots = newSeqUninit[Digest](i.len)
       for x in roots.mitems:
         x.data[0] = 0xba
         x.data[1] = 0xad
@@ -2096,11 +2088,7 @@ suite "Merkleization types":
         i.toSeq
       checkpoint $i.mapIt(toBin(it.int64))
       let r = i.mapIt(roots.getOrDefault(it.int64))
-      var roots =
-        when (NimMajor, NimMinor) < (2, 2):
-          newSeq[Digest](i.len)
-        else:
-          newSeqUninit[Digest](i.len)
+      var roots = newSeqUninit[Digest](i.len)
       hash_tree_root(x, i, roots).get
       check:
         roots == r
@@ -2170,11 +2158,7 @@ suite "Merkleization types":
     ]
     for i in tests:
       checkpoint $i
-      var roots =
-        when (NimMajor, NimMinor) < (2, 2):
-          newSeq[Digest](i.len)
-        else:
-          newSeqUninit[Digest](i.len)
+      var roots = newSeqUninit[Digest](i.len)
       for x in roots.mitems:
         x.data[0] = 0xba
         x.data[1] = 0xad


### PR DESCRIPTION
Drop legacy Nim 2.0 support, to avoid having to keep working around limitations such as `newSeqUninit` being unavailable. New minimum is Nim 2.2.10.