### PR TITLE
Convenience API for fetching top root together with indices

### DIFF
--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -2623,6 +2623,7 @@ func hash_tree_root*(
     topRoot: var Digest
 ): Result[seq[Digest], string] =
   if indices.len == 0:
+    topRoot = hash_tree_root(x)
     ok(newSeq[Digest](0))
   elif indices.len == 1 and indices[0] == 1.GeneralizedIndex:
     topRoot = hash_tree_root(x)
@@ -2674,6 +2675,7 @@ func hash_tree_root*(
 ): auto =
   type ResultType = Result[array[indices.len, Digest], string]
   when indices.len == 0:
+    topRoot = hash_tree_root(x)
     ResultType.ok([])
   else:
     when indices.len == 1 and indices[0] == 1.GeneralizedIndex:

--- a/ssz_serialization/merkleization.nim
+++ b/ssz_serialization/merkleization.nim
@@ -2610,11 +2610,34 @@ func hash_tree_root*(
     let loopOrder = merkleizationLoopOrder(indices)
     ? validateIndices(indices, loopOrder)
     var
-      roots = newSeq[Digest](indices.len)
+      roots = newSeqUninit[Digest](indices.len)
       batch = BatchRequest.init(indices, roots, loopOrder)
     let numFulfilled = hash_tree_root_multi(x, addr batch).valueOr:
       return err(unsupportedIndex)
     doAssert numFulfilled == loopOrder.len
+    ok(roots)
+
+func hash_tree_root*(
+    x: auto,
+    indices: openArray[GeneralizedIndex],
+    topRoot: var Digest
+): Result[seq[Digest], string] =
+  if indices.len == 0:
+    ok(newSeq[Digest](0))
+  elif indices.len == 1 and indices[0] == 1.GeneralizedIndex:
+    topRoot = hash_tree_root(x)
+    ok(@[topRoot])
+  else:
+    let loopOrder = merkleizationLoopOrder(indices)
+    ? validateIndices(indices, loopOrder)
+    var
+      roots = newSeqUninit[Digest](indices.len)
+      batch = BatchRequest.init(indices, roots, loopOrder)
+    let numFulfilled = hash_tree_root_multi(
+        x, addr batch, needTopRoot = true).valueOr:
+      return err(unsupportedIndex)
+    doAssert numFulfilled == loopOrder.len
+    topRoot = batch.topRoot
     ok(roots)
 
 func hash_tree_root*(
@@ -2642,6 +2665,36 @@ func hash_tree_root*(
           ResultType.err(unsupportedIndex)
         else:
           doAssert w.get == loopOrder.len
+          ResultType.ok(roots)
+
+func hash_tree_root*(
+    x: auto,
+    indices: static openArray[GeneralizedIndex],
+    topRoot: var Digest
+): auto =
+  type ResultType = Result[array[indices.len, Digest], string]
+  when indices.len == 0:
+    ResultType.ok([])
+  else:
+    when indices.len == 1 and indices[0] == 1.GeneralizedIndex:
+      topRoot = hash_tree_root(x)
+      ResultType.ok([topRoot])
+    else:
+      const
+        loopOrder = merkleizationLoopOrder(indices)
+        v = validateIndices(indices, loopOrder)
+      when v.isErr:
+        ResultType.err(v.error)
+      else:
+        var
+          roots {.noinit.}: array[indices.len, Digest]
+          batch = BatchRequest.init(indices, roots, loopOrder)
+        let w = hash_tree_root_multi(x, addr batch, needTopRoot = true)
+        if w.isErr:
+          ResultType.err(unsupportedIndex)
+        else:
+          doAssert w.get == loopOrder.len
+          topRoot = batch.topRoot
           ResultType.ok(roots)
 
 func hash_tree_root*(

--- a/ssz_serialization/proofs.nim
+++ b/ssz_serialization/proofs.nim
@@ -78,7 +78,8 @@ iterator get_path_indices*(
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/ssz/merkle-proofs.md#merkle-multiproofs
 func get_helper_indices_impl(
     withPathIndices: static bool,
-    indices: varargs[GeneralizedIndex]): seq[GeneralizedIndex] =
+    indices: openArray[GeneralizedIndex],
+    extra_indices: openArray[GeneralizedIndex] = []): seq[GeneralizedIndex] =
   ## Get the generalized indices of all "extra" chunks in the tree needed
   ## to prove the chunks with the given generalized indices. Note that the
   ## decreasing order is chosen deliberately to ensure equivalence to the order
@@ -91,6 +92,8 @@ func get_helper_indices_impl(
     for index in indices:
       for idx in get_path_indices(index):
         all_helper_indices.excl idx
+  for idx in extra_indices:
+    all_helper_indices.incl idx
 
   var res = newSeqOfCap[GeneralizedIndex](all_helper_indices.len)
   for idx in all_helper_indices.items():
@@ -105,6 +108,11 @@ template get_helper_indices*(
 template get_union_indices*(
     indices: varargs[GeneralizedIndex]): seq[GeneralizedIndex] =
   get_helper_indices_impl(withPathIndices = true, indices)
+
+template get_union_indices*(
+    indices: openArray[GeneralizedIndex],
+    extra_indices: openArray[GeneralizedIndex]): seq[GeneralizedIndex] =
+  get_helper_indices_impl(withPathIndices = true, indices, extra_indices)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/ssz/merkle-proofs.md#merkle-multiproofs
 func check_multiproof_acceptable*(
@@ -409,7 +417,7 @@ func extract_branch*(
     roots: openArray[Digest],
     union_indices: openArray[GeneralizedIndex],
     indices: openArray[GeneralizedIndex]): Result[seq[Digest], string] =
-  var branch = newSeq[Digest](indices.len)
+  var branch = newSeqUninit[Digest](indices.len)
   ? roots.extract_branch(union_indices, indices, branch)
   ok branch
 
@@ -419,11 +427,9 @@ func extract_branch*(
     indices: static openArray[GeneralizedIndex]): auto =
   type ResultType = Result[array[indices.len, Digest], string]
   var branch {.noinit.}: array[indices.len, Digest]
-  let v = roots.extract_branch(union_indices, indices, branch)
-  if v.isErr:
-    ResultType.err(v.error)
-  else:
-    ResultType.ok(branch)
+  roots.extract_branch(union_indices, indices, branch).isOkOr:
+    return ResultType.err(error)
+  ResultType.ok(branch)
 
 func extract_branch*(
     roots: openArray[Digest],
@@ -438,6 +444,14 @@ func extract_branch*(
     index: static GeneralizedIndex): auto =
   const indices = get_helper_indices(index)
   roots.extract_branch(union_indices, indices)
+
+func extract_root*(
+    roots: openArray[Digest],
+    union_indices: openArray[GeneralizedIndex],
+    index: GeneralizedIndex | static GeneralizedIndex): Result[Digest, string] =
+  let branch = ? roots.extract_branch(union_indices, [index])
+  doAssert branch.len == 1
+  ok(branch[0])
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.6/specs/phase0/beacon-chain.md#compute_merkle_branch_root
 func compute_merkle_branch_root*(


### PR DESCRIPTION
Followup from #199 that retargets the convenience API to a lower level. Can sometimes be useful to obtain both a proof as well as the top hash_tree_root in the same pass, to avoid repeated hash computation.